### PR TITLE
Add download section and installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,22 @@ PullRead fetches entries from your RSS/Atom feeds, extracts article content usin
 
 ---
 
+## Download
+
+**[Download the latest release](https://github.com/shellen/pullread/releases/latest)**
+
+| Platform | Download | Notes |
+|----------|----------|-------|
+| **macOS** | [PullReadTray.dmg](https://github.com/shellen/pullread/releases/latest/download/PullReadTray.dmg) | Menu bar app for one-click sync |
+| **CLI** | Clone this repo | Works on macOS, Linux, Windows |
+
+> **Quick install:** Download the DMG, open it, drag PullReadTray to your Applications folder, and launch it. The app will guide you through setup on first run.
+
+---
+
 ## Table of Contents
 
+- [Download](#download)
 - [Features](#features)
 - [Quick Start](#quick-start)
 - [Installation](#installation)


### PR DESCRIPTION
## Summary
Added a new "Download" section to the README with direct links to the latest release and platform-specific installation instructions.

## Changes
- Added a new "Download" section with links to the latest release
- Created a platform comparison table showing:
  - macOS DMG download for the menu bar app (PullReadTray)
  - CLI installation instructions for cross-platform use
- Added quick install instructions for the macOS app
- Updated the Table of Contents to include the new Download section

## Details
This change improves the user experience by making it immediately clear how to get started with PullRead. Users can now quickly find download links for both the convenient macOS menu bar application and the CLI version without having to search through the repository.

https://claude.ai/code/session_011mpnqdf9CFmxcUb5VfHjB3