### PR TITLE
Fix release job conditions to explicitly check build success

### DIFF
--- a/.github/workflows/build-macos-app.yml
+++ b/.github/workflows/build-macos-app.yml
@@ -150,7 +150,7 @@ jobs:
 
   release:
     needs: build
-    if: github.event.inputs.create_release == 'true' || startsWith(github.ref, 'refs/tags/v')
+    if: always() && needs.build.result == 'success' && (github.event.inputs.create_release == 'true' || startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -174,7 +174,7 @@ jobs:
   # Auto-update "latest" release on every push to main
   latest-release:
     needs: build
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: always() && needs.build.result == 'success' && github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
Updated the conditional logic for the `release` and `latest-release` jobs to explicitly check that the `build` job completed successfully before proceeding, using `always() && needs.build.result == 'success'`.

## Changes
- **release job**: Added explicit build success check to the existing condition for manual releases and tag-based releases
- **latest-release job**: Added explicit build success check to the existing condition for automatic latest release updates on main branch pushes

## Details
Previously, these jobs relied on implicit dependency handling through the `needs: build` declaration. By adding `always() && needs.build.result == 'success'`, we:
- Ensure the job condition is explicitly evaluated even if the build job is skipped
- Prevent release jobs from running if the build job fails
- Make the dependency relationship more explicit and maintainable in the workflow logic

https://claude.ai/code/session_01BXMAVwNNBVJ31EDeJ2UEHq