### PR TITLE
Expand macOS build workflow triggers to include src and package files

### DIFF
--- a/.github/workflows/build-macos-app.yml
+++ b/.github/workflows/build-macos-app.yml
@@ -8,11 +8,17 @@ on:
     branches: [main, 'claude/**']
     paths:
       - 'PullReadTray/**'
+      - 'src/**'
+      - 'package.json'
+      - 'package-lock.json'
       - '.github/workflows/build-macos-app.yml'
   pull_request:
     branches: [main]
     paths:
       - 'PullReadTray/**'
+      - 'src/**'
+      - 'package.json'
+      - 'package-lock.json'
   workflow_dispatch:
     inputs:
       create_release:


### PR DESCRIPTION
## Summary
Updated the macOS build workflow to trigger on changes to additional source files and dependency configurations, ensuring the build pipeline runs whenever relevant code or dependencies are modified.

## Key Changes
- Added `src/**` to workflow triggers to monitor source code changes
- Added `package.json` to workflow triggers to detect dependency updates
- Added `package-lock.json` to workflow triggers to detect lock file changes
- Applied these path filters to both `push` (main and claude/** branches) and `pull_request` (main branch) events

## Details
Previously, the workflow only monitored changes in the `PullReadTray/` directory and the workflow file itself. This update expands coverage to include the main source directory and package management files, ensuring builds are triggered whenever dependencies are updated or source code in the `src/` directory changes. This prevents stale builds and ensures the macOS app is always built with the latest code and dependencies.

https://claude.ai/code/session_01NgsstNkvGSzboVVfXh6nby