### PR TITLE
fix: open browser when launching markdown reader from tray

### DIFF
--- a/PullReadTray/PullReadTray/SyncService.swift
+++ b/PullReadTray/PullReadTray/SyncService.swift
@@ -202,6 +202,14 @@ class SyncService {
             do {
                 try process.run()
                 self.viewerProcess = process
+
+                // Wait briefly for the server to start listening, then open the browser
+                Thread.sleep(forTimeInterval: 0.5)
+                DispatchQueue.main.async {
+                    let url = URL(string: "http://localhost:\(self.viewerPort)")!
+                    NSWorkspace.shared.open(url)
+                }
+
                 completion(.success(()))
             } catch {
                 completion(.failure(error))


### PR DESCRIPTION
The openViewer method started the viewer server process but never
opened the browser on the first invocation. The browser was only
opened on subsequent clicks when the server was already running.
Now the browser opens automatically after starting the server.

https://claude.ai/code/session_01JhT5hkYSGh4B5jnohmzwDj