### PR TITLE
fix: resolve viewer.html not found in packaged app

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -124,8 +124,9 @@ bundle_cli() {
     APP_PATH="$PROJECT_DIR/build/Build/Products/Release/$APP_NAME.app"
     RESOURCES_PATH="$APP_PATH/Contents/Resources"
 
-    # Copy binary
+    # Copy binary and viewer.html
     cp "$ROOT_DIR/dist/pullread" "$RESOURCES_PATH/"
+    cp "$ROOT_DIR/viewer.html" "$RESOURCES_PATH/"
 
     # Sign the binary
     codesign --force --sign "Developer ID Application" "$RESOURCES_PATH/pullread"

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -6,7 +6,12 @@ import { readFileSync, readdirSync, statSync, existsSync } from 'fs';
 import { join, extname } from 'path';
 import { exec } from 'child_process';
 
-const VIEWER_HTML_PATH = join(__dirname, '..', 'viewer.html');
+// In development, __dirname is src/ so viewer.html is in the parent directory.
+// In compiled binaries (bun --compile), __dirname is the directory of the executable,
+// so viewer.html should be alongside the binary.
+const VIEWER_HTML_PATH = existsSync(join(__dirname, '..', 'viewer.html'))
+  ? join(__dirname, '..', 'viewer.html')
+  : join(__dirname, 'viewer.html');
 
 interface FileMeta {
   filename: string;


### PR DESCRIPTION
The viewer.html path was hardcoded to look in the parent directory of
__dirname, which works in development (src/../viewer.html) but fails
in compiled binaries where __dirname is the executable's directory.
Now tries both locations. Also copies viewer.html into the app bundle
Resources directory during the release build.

https://claude.ai/code/session_01FC7eGQNEBgaBkDojPudyzZ