### PR TITLE
Fix Sparkle download URLs to dynamically resolve latest version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,8 +168,10 @@ jobs:
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: |
-          # Download Sparkle tools
-          curl -L -o Sparkle.tar.xz "https://github.com/sparkle-project/Sparkle/releases/latest/download/Sparkle-2.7.5.tar.xz"
+          # Fetch latest Sparkle release tag dynamically to avoid hardcoded version mismatch
+          SPARKLE_TAG=$(curl -s https://api.github.com/repos/sparkle-project/Sparkle/releases/latest | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'])")
+          echo "Downloading Sparkle ${SPARKLE_TAG}"
+          curl -L -o Sparkle.tar.xz "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_TAG}/Sparkle-${SPARKLE_TAG}.tar.xz"
           mkdir -p sparkle-tools
           tar -xf Sparkle.tar.xz -C sparkle-tools
 

--- a/.github/workflows/sparkle-keygen.yml
+++ b/.github/workflows/sparkle-keygen.yml
@@ -16,7 +16,10 @@ jobs:
 
       - name: Download Sparkle
         run: |
-          curl -L -o Sparkle.tar.xz "https://github.com/sparkle-project/Sparkle/releases/latest/download/Sparkle-2.7.5.tar.xz"
+          # Fetch latest Sparkle release tag dynamically to avoid hardcoded version mismatch
+          SPARKLE_TAG=$(curl -s https://api.github.com/repos/sparkle-project/Sparkle/releases/latest | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'])")
+          echo "Downloading Sparkle ${SPARKLE_TAG}"
+          curl -L -o Sparkle.tar.xz "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_TAG}/Sparkle-${SPARKLE_TAG}.tar.xz"
           mkdir -p sparkle-tools
           tar -xf Sparkle.tar.xz -C sparkle-tools
 


### PR DESCRIPTION
The workflows hardcoded Sparkle-2.7.5.tar.xz in a /releases/latest/
download URL, which breaks when Sparkle releases a newer version
(currently 2.8.1) because the asset filename no longer matches. Now
fetches the latest release tag via the GitHub API and constructs the
correct pinned download URL.

https://claude.ai/code/session_01LyU2rm38faBTiEf2thGbdR