### PR TITLE
Fix Pages deployment by enabling automatic Pages setup

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
The `actions/configure-pages@v5` action fails with "Not Found" when
GitHub Pages hasn't been enabled in the repository settings. Adding
`enablement: true` tells the action to automatically enable Pages
(configured for GitHub Actions builds) if it isn't already set up.

https://claude.ai/code/session_01FSQ15vdnQehCSGNaFWwGfq