### PR TITLE
Trigger Pages deploy on workflow file changes

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'site/**'
+      - '.github/workflows/deploy-site.yml'
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages


### PR DESCRIPTION
The previous fix (enablement: true) was not automatically tested
because the paths filter only matched site/** files. Adding the
workflow file itself to the paths trigger ensures workflow changes
re-run the deployment pipeline.

https://claude.ai/code/session_01QTkgTrLq57nqEShsCyTW5Y