### PR TITLE
Point download buttons directly to DMG instead of GitHub releases page

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -595,7 +595,7 @@
     <li><a href="#reader">Reader</a></li>
     <li><a href="#format">Format</a></li>
     <li><a href="https://github.com/shellen/pullread" class="btn btn-sm btn-secondary">GitHub</a></li>
-    <li><a href="https://github.com/shellen/pullread/releases/latest" class="btn btn-sm btn-primary">Download</a></li>
+    <li><a href="https://github.com/shellen/pullread/releases/download/latest/PullRead.dmg" class="btn btn-sm btn-primary">Download</a></li>
   </ul>
 </nav>
 
@@ -614,7 +614,7 @@
   <h1>Own your <span class="accent">reading list</span></h1>
   <p>Pull Read saves articles from your bookmark services as clean markdown files. Your reading archive, in a folder you control.</p>
   <div class="hero-buttons">
-    <a href="https://github.com/shellen/pullread/releases/latest" class="btn btn-primary">
+    <a href="https://github.com/shellen/pullread/releases/download/latest/PullRead.dmg" class="btn btn-primary">
       <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 12V2M4 8l4 4 4-4M2 14h12"/></svg>
       Download for macOS
     </a>
@@ -858,7 +858,7 @@ Compatible with any tool.</pre>
   <h2>Start owning your reading list</h2>
   <p>Free and open source. Download the macOS app or clone the repo to get started in minutes.</p>
   <div class="cta-buttons">
-    <a href="https://github.com/shellen/pullread/releases/latest" class="btn btn-primary">
+    <a href="https://github.com/shellen/pullread/releases/download/latest/PullRead.dmg" class="btn btn-primary">
       <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 12V2M4 8l4 4 4-4M2 14h12"/></svg>
       Download for macOS
     </a>


### PR DESCRIPTION
The three download links on the marketing site now trigger an
immediate file download of PullRead.dmg rather than sending users
to the GitHub releases page first.

https://claude.ai/code/session_01XR6ktugfdcbRiMCD2yGfNy