### PR TITLE
Replace 'own your reading list' messaging with 'keep what you read'

### DIFF
--- a/.github/workflows/build-macos-app.yml
+++ b/.github/workflows/build-macos-app.yml
@@ -415,7 +415,7 @@ jobs:
           body: |
             This is the latest build of Pull Read from the main branch.
 
-            The app is self-contained with the CLI binary bundled—no Node.js required.
+            The app is self-contained with the CLI binary bundled—nothing else to install.
 
             **Download:** [PullRead.dmg](https://github.com/${{ github.repository }}/releases/download/latest/PullRead.dmg)
 

--- a/PullReadTray/PullReadTray/OnboardingView.swift
+++ b/PullReadTray/PullReadTray/OnboardingView.swift
@@ -93,7 +93,7 @@ struct OnboardingView: View {
                 .font(.largeTitle)
                 .fontWeight(.bold)
 
-            Text("Save articles from your bookmark services as clean markdown files you own. Connect Instapaper, Pinboard, Raindrop, or any service with an RSS feed.")
+            Text("Save articles from your bookmark services as clean, local markdown files. Connect Instapaper, Pinboard, Raindrop, or any service with an RSS feed.")
                 .font(.body)
                 .foregroundColor(.secondary)
                 .multilineTextAlignment(.center)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PullRead
 
-**Save articles from your bookmark services as clean markdown files you own.**
+**Save articles from your bookmark services as clean, local markdown files.**
 
 PullRead connects to bookmark services like Instapaper, Pinboard, Raindrop, and Omnivore (via their RSS feeds), extracts article content using Mozilla's Readability algorithm, and saves them as beautifully formatted markdown files with YAML frontmatter. It also handles RSS/Atom feeds, podcasts, YouTube videos (with transcripts), and more. Perfect for building a local, searchable reading archive synced to Dropbox, iCloud, or any folder you choose.
 
@@ -975,4 +975,4 @@ Contributions are welcome! Here's how to get started:
 
 ---
 
-**Made with care for anyone who wants to own their reading list.**
+**Made with care for anyone who wants to keep what they read.**

--- a/site/index.html
+++ b/site/index.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Pull Read - Own Your Reading List</title>
-<meta name="description" content="Save articles from your bookmark services as clean markdown files you own. Connect Instapaper, Pinboard, Raindrop, and more.">
+<title>Pull Read - Keep What You Read</title>
+<meta name="description" content="Save articles from your bookmark services as clean, local markdown files. Connect Instapaper, Pinboard, Raindrop, and more.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
@@ -611,7 +611,7 @@
       <path d="M49 6v18l6-4.5L61 24V6z" fill="#e76f51"/>
     </svg>
   </div>
-  <h1>Own your <span class="accent">reading list</span></h1>
+  <h1>Keep what <span class="accent">you read</span></h1>
   <p>Pull Read saves articles from your bookmark services as clean markdown files. Your reading archive, in a folder you control.</p>
   <div class="hero-buttons">
     <a href="https://github.com/shellen/pullread/releases/download/latest/PullRead.dmg" class="btn btn-primary">
@@ -620,7 +620,7 @@
     </a>
     <a href="https://github.com/shellen/pullread" class="btn btn-secondary">View on GitHub</a>
   </div>
-  <p class="hero-note">Self-contained menu bar app. No Node.js required.</p>
+  <p class="hero-note">Self-contained menu bar app. Nothing else to install.</p>
 </section>
 
 <!-- How it works -->
@@ -628,7 +628,7 @@
   <div class="container">
     <div style="text-align: center;">
       <div class="section-label">How it works</div>
-      <h2 class="section-title">Three steps to owning your articles</h2>
+      <h2 class="section-title">Three steps to keeping your articles</h2>
     </div>
     <div class="steps">
       <div class="step">
@@ -855,7 +855,7 @@ Compatible with any tool.</pre>
 
 <!-- CTA -->
 <section class="cta">
-  <h2>Start owning your reading list</h2>
+  <h2>Start keeping what you read</h2>
   <p>Free and open source. Download the macOS app or clone the repo to get started in minutes.</p>
   <div class="cta-buttons">
     <a href="https://github.com/shellen/pullread/releases/download/latest/PullRead.dmg" class="btn btn-primary">


### PR DESCRIPTION
Reframes marketing angle away from ownership/IP language toward
preservation. Also removes Node.js reference from homepage hero note.

https://claude.ai/code/session_011pYBZ1JMop5gF6Hrwvmbhn