### PR TITLE
Fix notarization by signing embedded Sparkle framework

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,7 @@ jobs:
             CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Developer ID Application" \
             DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
+            ENABLE_HARDENED_RUNTIME=YES \
             clean build
 
       - name: Bundle CLI binary into app
@@ -116,6 +117,34 @@ jobs:
 
           # Copy binary to app resources
           cp dist/pullread "$RESOURCES_PATH/"
+
+          # Re-sign all embedded frameworks for notarization.
+          # Sparkle (via SPM) includes nested executables (Autoupdate, Updater.app,
+          # Installer.xpc) that all need hardened runtime + secure timestamps.
+          # Xcode's build-time signing may not apply these flags to SPM dependencies.
+          # Sign from inside out: individual Mach-O binaries first, then bundles
+          # from deepest to shallowest.
+          if [ -d "$APP_PATH/Contents/Frameworks" ]; then
+            echo "Signing embedded frameworks..."
+
+            # 1. Sign all Mach-O binaries inside Frameworks/
+            find "$APP_PATH/Contents/Frameworks" -type f | while read -r f; do
+              if file "$f" | grep -qE "Mach-O"; then
+                echo "  Signing binary: $f"
+                codesign --force --options runtime --timestamp \
+                  --sign "$IDENTITY" "$f"
+              fi
+            done
+
+            # 2. Sign all sub-bundles (.xpc, .app) deepest first, then .framework
+            find "$APP_PATH/Contents/Frameworks" -depth \
+              \( -name "*.xpc" -o -name "*.app" -o -name "*.framework" \) \
+              -type d | while read -r bundle; do
+              echo "  Signing bundle: $bundle"
+              codesign --force --options runtime --timestamp \
+                --sign "$IDENTITY" "$bundle"
+            done
+          fi
 
           # Sign the bundled CLI binary (hardened runtime + timestamp required for notarization)
           codesign --force --options runtime --timestamp \
@@ -135,6 +164,11 @@ jobs:
           # Verify signing
           codesign -dv --verbose=2 "$APP_PATH"
           codesign -d --verbose=2 "$APP_PATH" 2>&1 | grep -i runtime
+
+          # Verify all nested code is properly signed before notarization
+          echo "Verifying all code signatures..."
+          codesign --verify --deep --strict "$APP_PATH"
+          echo "All signatures valid."
 
           # Free disk space: remove intermediate build artifacts
           rm -rf dist


### PR DESCRIPTION
The release build was failing notarization because the Sparkle framework (and its nested executables: Autoupdate, Updater.app, Installer.xpc) inside Contents/Frameworks/ were not being re-signed with hardened runtime and secure timestamps after the Xcode build.

The previous fix (aa0e0e9) added --options runtime and --timestamp to the CLI binary and main app binary signing, but missed the embedded frameworks entirely. Apple's notarization service requires ALL executables and dylibs to have hardened runtime + secure timestamps.

Changes:
- Add inside-out framework signing: find all Mach-O binaries in Frameworks/, sign them individually, then sign sub-bundles deepest first
- Add ENABLE_HARDENED_RUNTIME=YES to xcodebuild for belt-and-suspenders
- Add codesign --verify --deep --strict pre-flight check before submitting to Apple, to catch signing issues early

https://claude.ai/code/session_014aAQ9ePwD1xj4Wu7zzYswz