### PR TITLE
Fix Sparkle DMG signing by using -f flag for key file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,7 +269,11 @@ jobs:
           tar -xf Sparkle.tar.xz -C sparkle-tools
 
           # Sign the DMG with Sparkle's EdDSA signature
-          SIGNATURE=$(echo "$SPARKLE_PRIVATE_KEY" | sparkle-tools/bin/sign_update PullRead.dmg)
+          # sign_update requires the key via -f flag (does not read from stdin)
+          KEY_FILE=$(mktemp)
+          echo "$SPARKLE_PRIVATE_KEY" > "$KEY_FILE"
+          SIGNATURE=$(sparkle-tools/bin/sign_update PullRead.dmg -f "$KEY_FILE")
+          rm -f "$KEY_FILE"
           echo "SPARKLE_SIGNATURE=$SIGNATURE" >> $GITHUB_ENV
           echo "Sparkle signature generated"
 


### PR DESCRIPTION
## Summary
Updated the DMG signing process in the release workflow to correctly pass the Sparkle private key to the `sign_update` tool using the `-f` flag instead of stdin.

## Changes
- Modified the `sign_update` command invocation to use the `-f` flag for specifying the key file path
- Created a temporary file to store the private key since `sign_update` requires the key via file argument rather than stdin
- Added cleanup to remove the temporary key file after signing is complete
- Added clarifying comment explaining the `-f` flag requirement

## Details
The Sparkle `sign_update` tool does not support reading the private key from stdin. This change creates a temporary file to hold the key and passes it via the `-f` flag as required by the tool, then properly cleans up the temporary file afterward.

https://claude.ai/code/session_01EwBktfK5kEV3Q3A1Fqz9jg