### PR TITLE
Use pullread.com/link redirect page for email roundup links

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +43,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -96,6 +114,15 @@ name = "anyhow"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object",
+]
 
 [[package]]
 name = "arbitrary"
@@ -520,6 +547,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chumsky"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
+dependencies = [
+ "hashbrown 0.14.5",
+ "stacker",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +959,22 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "email-encoding"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9298e6504d9b9e780ed3f7dfd43a61be8cd0e09eb07f7706a945b0072b6670b6"
+dependencies = [
+ "base64 0.22.1",
+ "memchr",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 
 [[package]]
 name = "embed-resource"
@@ -1573,6 +1626,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1663,6 +1720,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
@@ -2089,6 +2152,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lettre"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e13e10e8818f8b2a60f52cb127041d388b89f3a96a62be9ceaffa22262fef7f"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chumsky",
+ "email-encoding",
+ "email_address",
+ "fastrand",
+ "futures-io",
+ "futures-util",
+ "httpdate",
+ "idna",
+ "mime",
+ "nom",
+ "percent-encoding",
+ "quoted_printable",
+ "rustls",
+ "socket2",
+ "tokio",
+ "tokio-rustls",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,6 +2422,15 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "notify-rust"
@@ -2605,6 +2705,15 @@ dependencies = [
  "objc2-foundation",
  "objc2-javascript-core",
  "objc2-security",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3089,12 +3198,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
 name = "pullread"
-version = "0.4.4"
+version = "0.4.6"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
  "env_logger",
+ "lettre",
  "log",
  "open",
  "portpicker",
@@ -3197,6 +3317,12 @@ checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "quoted_printable"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c9bd8497b02465aeef5375144c26062e0dcd5939dfcbb0f5db76cb8c17c73"
 
 [[package]]
 name = "r-efi"
@@ -3568,6 +3694,7 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4096,6 +4223,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "string_cache"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ env_logger = "0.11"
 dirs = "6"
 open = "5"
 reqwest = { version = "0.12", features = ["rustls-tls"], default-features = false }
+lettre = { version = "0.11", features = ["tokio1-rustls-tls", "smtp-transport", "builder"], default-features = false }
 url = "2"
 urlencoding = "2"
 

--- a/src-tauri/src/email.rs
+++ b/src-tauri/src/email.rs
@@ -50,6 +50,7 @@ impl Default for EmailConfig {
 
 /// Article summary for the roundup email
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct ArticleMeta {
     filename: String,
     title: String,
@@ -220,6 +221,7 @@ pub async fn send_roundup(app: &AppHandle) -> Result<String, String> {
 
     let articles = fetch_recent_articles(port, config.lookback_days).await?;
     let html = build_roundup_html(&articles, config.lookback_days);
+    let count = articles.len();
 
     let from: Mailbox = config
         .from_address
@@ -243,54 +245,30 @@ pub async fn send_roundup(app: &AppHandle) -> Result<String, String> {
 
     let creds = Credentials::new(config.smtp_user.clone(), config.smtp_pass.clone());
 
-    let transport = if config.use_tls {
+    let mailer = if config.use_tls {
         AsyncSmtpTransport::<Tokio1Executor>::relay(&config.smtp_host)
-    } else {
-        AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(&config.smtp_host)
+            .map_err(|e| format!("SMTP connection failed: {}", e))?
             .port(config.smtp_port)
-            .build();
-        // For non-TLS we need a different path
-        return send_with_starttls(email, &config).await;
+            .credentials(creds)
+            .build()
+    } else {
+        AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&config.smtp_host)
+            .map_err(|e| format!("SMTP STARTTLS connection failed: {}", e))?
+            .port(config.smtp_port)
+            .credentials(creds)
+            .build()
     };
-
-    let mailer = transport
-        .map_err(|e| format!("SMTP connection failed: {}", e))?
-        .port(config.smtp_port)
-        .credentials(creds)
-        .build();
 
     mailer
         .send(email)
         .await
         .map_err(|e| format!("Failed to send email: {}", e))?;
 
-    let count = articles.len();
     Ok(format!(
         "Roundup sent with {} article{}",
         count,
         if count == 1 { "" } else { "s" }
     ))
-}
-
-/// Send email using STARTTLS (port 587 typical)
-async fn send_with_starttls(
-    email: Message,
-    config: &EmailConfig,
-) -> Result<String, String> {
-    let creds = Credentials::new(config.smtp_user.clone(), config.smtp_pass.clone());
-
-    let mailer = AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&config.smtp_host)
-        .map_err(|e| format!("SMTP STARTTLS connection failed: {}", e))?
-        .port(config.smtp_port)
-        .credentials(creds)
-        .build();
-
-    mailer
-        .send(email)
-        .await
-        .map_err(|e| format!("Failed to send email: {}", e))?;
-
-    Ok("Roundup sent".to_string())
 }
 
 /// Send a test email to verify SMTP configuration

--- a/src-tauri/src/email.rs
+++ b/src-tauri/src/email.rs
@@ -92,10 +92,12 @@ async fn fetch_recent_articles(
     let resp = reqwest::get(&url)
         .await
         .map_err(|e| format!("Failed to fetch articles: {}", e))?;
-    let articles: Vec<ArticleMeta> = resp
-        .json()
+    let body = resp
+        .text()
         .await
-        .map_err(|e| format!("Failed to parse articles: {}", e))?;
+        .map_err(|e| format!("Failed to read articles response: {}", e))?;
+    let articles: Vec<ArticleMeta> =
+        serde_json::from_str(&body).map_err(|e| format!("Failed to parse articles: {}", e))?;
 
     let cutoff = chrono::Utc::now() - chrono::Duration::days(lookback_days as i64);
     let cutoff_str = cutoff.to_rfc3339();

--- a/src-tauri/src/email.rs
+++ b/src-tauri/src/email.rs
@@ -157,10 +157,11 @@ fn build_roundup_html(articles: &[ArticleMeta], lookback_days: u32) -> String {
                 )
             };
 
-            // Link to pullread://open?file=filename for deep linking
+            // Use pullread.com/link redirect page — email clients block custom URL schemes
             let pr_link = format!(
-                "pullread://open?file={}",
-                urlencoding::encode(&article.filename)
+                "https://pullread.com/link?url={}&title={}",
+                urlencoding::encode(&article.url),
+                urlencoding::encode(&article.title)
             );
 
             html.push_str(&format!(
@@ -186,7 +187,7 @@ fn build_roundup_html(articles: &[ArticleMeta], lookback_days: u32) -> String {
         r#"</div>
 <p style="text-align:center;font-size:11px;color:#aaa;margin-top:16px">
 Sent by <a href="https://pullread.com" style="color:#aaa">Pull Read</a> &middot;
-<a href="pullread://open?file=tab%3Dsettings%26section%3Dsettings-email" style="color:#aaa">Manage email settings</a>
+Open Pull Read and go to Settings to manage your email roundup
 </p>
 </div>
 </body>

--- a/src-tauri/src/email.rs
+++ b/src-tauri/src/email.rs
@@ -1,0 +1,359 @@
+// ABOUTME: Email roundup module for sending daily digest emails
+// ABOUTME: Uses lettre SMTP to deliver HTML roundups linking back to PullRead
+
+use crate::sidecar::SidecarState;
+use lettre::message::{header::ContentType, Mailbox};
+use lettre::transport::smtp::authentication::Credentials;
+use lettre::{AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+
+/// Email configuration stored in settings.json under "emailRoundup"
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EmailConfig {
+    pub enabled: bool,
+    pub smtp_host: String,
+    pub smtp_port: u16,
+    pub smtp_user: String,
+    pub smtp_pass: String,
+    pub use_tls: bool,
+    pub from_address: String,
+    pub to_address: String,
+    /// Time of day to send, e.g. "08:00"
+    pub send_time: String,
+    /// How many days of articles to include (default 1)
+    #[serde(default = "default_lookback")]
+    pub lookback_days: u32,
+}
+
+fn default_lookback() -> u32 {
+    1
+}
+
+impl Default for EmailConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            smtp_host: String::new(),
+            smtp_port: 587,
+            smtp_user: String::new(),
+            smtp_pass: String::new(),
+            use_tls: true,
+            from_address: String::new(),
+            to_address: String::new(),
+            send_time: "08:00".to_string(),
+            lookback_days: 1,
+        }
+    }
+}
+
+/// Article summary for the roundup email
+#[derive(Debug, Deserialize)]
+struct ArticleMeta {
+    filename: String,
+    title: String,
+    url: String,
+    domain: String,
+    #[serde(default)]
+    author: String,
+    #[serde(default)]
+    feed: String,
+    #[serde(default)]
+    bookmarked: String,
+}
+
+/// Load email config from settings.json
+pub fn load_email_config(app: &AppHandle) -> EmailConfig {
+    let state = app.state::<SidecarState>();
+    let path = state
+        .config_path()
+        .parent()
+        .unwrap_or(std::path::Path::new("/tmp"))
+        .join("settings.json");
+
+    std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|c| serde_json::from_str::<serde_json::Value>(&c).ok())
+        .and_then(|v| {
+            v.get("emailRoundup")
+                .and_then(|e| serde_json::from_value(e.clone()).ok())
+        })
+        .unwrap_or_default()
+}
+
+/// Fetch recent articles from the viewer's /api/files endpoint
+async fn fetch_recent_articles(
+    port: u16,
+    lookback_days: u32,
+) -> Result<Vec<ArticleMeta>, String> {
+    let url = format!("http://127.0.0.1:{}/api/files", port);
+    let resp = reqwest::get(&url)
+        .await
+        .map_err(|e| format!("Failed to fetch articles: {}", e))?;
+    let articles: Vec<ArticleMeta> = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse articles: {}", e))?;
+
+    let cutoff = chrono::Utc::now() - chrono::Duration::days(lookback_days as i64);
+    let cutoff_str = cutoff.to_rfc3339();
+
+    let recent: Vec<ArticleMeta> = articles
+        .into_iter()
+        .filter(|a| {
+            if a.bookmarked.is_empty() {
+                return false;
+            }
+            a.bookmarked >= cutoff_str
+        })
+        .collect();
+
+    Ok(recent)
+}
+
+/// Build the HTML email body
+fn build_roundup_html(articles: &[ArticleMeta], lookback_days: u32) -> String {
+    let today = chrono::Local::now().format("%B %-d, %Y").to_string();
+    let period = if lookback_days == 1 {
+        "today".to_string()
+    } else {
+        format!("the last {} days", lookback_days)
+    };
+
+    let mut html = format!(
+        r#"<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width"></head>
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#f5f5f5">
+<div style="max-width:600px;margin:0 auto;padding:20px">
+<div style="background:#fff;border-radius:12px;padding:32px;border:1px solid #e0e0e0">
+<h1 style="margin:0 0 4px;font-size:22px;color:#1a1a1a">Pull Read Roundup</h1>
+<p style="margin:0 0 24px;font-size:14px;color:#888">{} &middot; {} article{} from {}</p>
+"#,
+        today,
+        articles.len(),
+        if articles.len() == 1 { "" } else { "s" },
+        period
+    );
+
+    if articles.is_empty() {
+        html.push_str(
+            r#"<p style="color:#666;font-size:15px">No new articles synced. Check back later!</p>"#,
+        );
+    } else {
+        for article in articles {
+            let domain_display = if article.domain.is_empty() {
+                &article.feed
+            } else {
+                &article.domain
+            };
+            let author_line = if article.author.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    r#" <span style="color:#888">&middot; {}</span>"#,
+                    html_escape(&article.author)
+                )
+            };
+
+            // Link to pullread://open?file=filename for deep linking
+            let pr_link = format!(
+                "pullread://open?file={}",
+                urlencoding::encode(&article.filename)
+            );
+
+            html.push_str(&format!(
+                r#"<div style="padding:12px 0;border-bottom:1px solid #f0f0f0">
+<a href="{}" style="font-size:15px;color:#1a1a1a;text-decoration:none;font-weight:500">{}</a>
+<div style="font-size:12px;margin-top:4px">
+<a href="{}" style="color:#888;text-decoration:none">{}</a>{}
+<span style="float:right"><a href="{}" style="color:#0066cc;text-decoration:none;font-size:11px">Read in PullRead &rarr;</a></span>
+</div>
+</div>
+"#,
+                html_escape(&article.url),
+                html_escape(&article.title),
+                html_escape(&article.url),
+                html_escape(domain_display),
+                author_line,
+                html_escape(&pr_link),
+            ));
+        }
+    }
+
+    html.push_str(
+        r#"</div>
+<p style="text-align:center;font-size:11px;color:#aaa;margin-top:16px">
+Sent by <a href="https://pullread.com" style="color:#aaa">Pull Read</a> &middot;
+<a href="pullread://open?file=tab%3Dsettings%26section%3Dsettings-email" style="color:#aaa">Manage email settings</a>
+</p>
+</div>
+</body>
+</html>"#,
+    );
+
+    html
+}
+
+/// HTML-escape a string for safe embedding
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// Send the roundup email via SMTP
+pub async fn send_roundup(app: &AppHandle) -> Result<String, String> {
+    let config = load_email_config(app);
+    if !config.enabled {
+        return Err("Email roundup is not enabled".to_string());
+    }
+    if config.smtp_host.is_empty() || config.to_address.is_empty() {
+        return Err("Email not configured: missing SMTP host or recipient".to_string());
+    }
+
+    // Ensure viewer is running so we can fetch articles
+    let port = crate::sidecar::ensure_viewer_running(app).await?;
+
+    let articles = fetch_recent_articles(port, config.lookback_days).await?;
+    let html = build_roundup_html(&articles, config.lookback_days);
+
+    let from: Mailbox = config
+        .from_address
+        .parse()
+        .map_err(|e| format!("Invalid from address: {}", e))?;
+    let to: Mailbox = config
+        .to_address
+        .parse()
+        .map_err(|e| format!("Invalid to address: {}", e))?;
+
+    let today = chrono::Local::now().format("%B %-d").to_string();
+    let subject = format!("Pull Read Roundup — {}", today);
+
+    let email = Message::builder()
+        .from(from)
+        .to(to)
+        .subject(subject)
+        .header(ContentType::TEXT_HTML)
+        .body(html)
+        .map_err(|e| format!("Failed to build email: {}", e))?;
+
+    let creds = Credentials::new(config.smtp_user.clone(), config.smtp_pass.clone());
+
+    let transport = if config.use_tls {
+        AsyncSmtpTransport::<Tokio1Executor>::relay(&config.smtp_host)
+    } else {
+        AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(&config.smtp_host)
+            .port(config.smtp_port)
+            .build();
+        // For non-TLS we need a different path
+        return send_with_starttls(email, &config).await;
+    };
+
+    let mailer = transport
+        .map_err(|e| format!("SMTP connection failed: {}", e))?
+        .port(config.smtp_port)
+        .credentials(creds)
+        .build();
+
+    mailer
+        .send(email)
+        .await
+        .map_err(|e| format!("Failed to send email: {}", e))?;
+
+    let count = articles.len();
+    Ok(format!(
+        "Roundup sent with {} article{}",
+        count,
+        if count == 1 { "" } else { "s" }
+    ))
+}
+
+/// Send email using STARTTLS (port 587 typical)
+async fn send_with_starttls(
+    email: Message,
+    config: &EmailConfig,
+) -> Result<String, String> {
+    let creds = Credentials::new(config.smtp_user.clone(), config.smtp_pass.clone());
+
+    let mailer = AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&config.smtp_host)
+        .map_err(|e| format!("SMTP STARTTLS connection failed: {}", e))?
+        .port(config.smtp_port)
+        .credentials(creds)
+        .build();
+
+    mailer
+        .send(email)
+        .await
+        .map_err(|e| format!("Failed to send email: {}", e))?;
+
+    Ok("Roundup sent".to_string())
+}
+
+/// Send a test email to verify SMTP configuration
+pub async fn send_test_email(app: &AppHandle) -> Result<String, String> {
+    let config = load_email_config(app);
+    if config.smtp_host.is_empty() || config.to_address.is_empty() {
+        return Err("Email not configured: missing SMTP host or recipient".to_string());
+    }
+
+    let from: Mailbox = config
+        .from_address
+        .parse()
+        .map_err(|e| format!("Invalid from address: {}", e))?;
+    let to: Mailbox = config
+        .to_address
+        .parse()
+        .map_err(|e| format!("Invalid to address: {}", e))?;
+
+    let email = Message::builder()
+        .from(from)
+        .to(to)
+        .subject("Pull Read — Test Email")
+        .header(ContentType::TEXT_HTML)
+        .body(
+            r#"<html><body style="font-family:sans-serif;padding:20px">
+<h2>Pull Read Email Test</h2>
+<p>Your email roundup is configured correctly! You'll receive daily roundups at your scheduled time.</p>
+</body></html>"#
+                .to_string(),
+        )
+        .map_err(|e| format!("Failed to build email: {}", e))?;
+
+    let creds = Credentials::new(config.smtp_user.clone(), config.smtp_pass.clone());
+
+    let mailer = if config.use_tls {
+        AsyncSmtpTransport::<Tokio1Executor>::relay(&config.smtp_host)
+            .map_err(|e| format!("SMTP connection failed: {}", e))?
+            .port(config.smtp_port)
+            .credentials(creds)
+            .build()
+    } else {
+        AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&config.smtp_host)
+            .map_err(|e| format!("SMTP STARTTLS connection failed: {}", e))?
+            .port(config.smtp_port)
+            .credentials(creds)
+            .build()
+    };
+
+    mailer
+        .send(email)
+        .await
+        .map_err(|e| format!("Failed to send test email: {}", e))?;
+
+    Ok("Test email sent successfully".to_string())
+}
+
+/// Tauri command: send a test email
+#[tauri::command]
+pub async fn cmd_send_test_email(app: AppHandle) -> Result<String, String> {
+    send_test_email(&app).await
+}
+
+/// Tauri command: trigger a roundup email manually
+#[tauri::command]
+pub async fn cmd_send_roundup(app: AppHandle) -> Result<String, String> {
+    send_roundup(&app).await
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod auth;
 mod commands;
+mod email;
 mod notifications;
 mod platform;
 mod sidecar;
@@ -88,6 +89,8 @@ pub fn run() {
             commands::trigger_review,
             commands::get_log_content,
             commands::print_webview,
+            email::cmd_send_test_email,
+            email::cmd_send_roundup,
             auth::open_site_login,
             auth::list_site_logins,
             auth::remove_site_login,

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -163,6 +163,14 @@ impl SidecarState {
             .to_string()
     }
 
+    /// Get email roundup config from settings.json
+    pub fn get_email_config_raw(&self) -> Option<serde_json::Value> {
+        let path = self.config_dir.join("settings.json");
+        let content = std::fs::read_to_string(&path).ok()?;
+        let config: serde_json::Value = serde_json::from_str(&content).ok()?;
+        config.get("emailRoundup").cloned()
+    }
+
     /// Check if viewer should open in the default browser instead of the WebView
     pub fn should_open_in_browser(&self) -> bool {
         let path = self.config_dir.join("settings.json");

--- a/src-tauri/src/timers.rs
+++ b/src-tauri/src/timers.rs
@@ -1,13 +1,14 @@
-// ABOUTME: Scheduled sync and review timers
+// ABOUTME: Scheduled sync, review, and email roundup timers
 // ABOUTME: Reads intervals from config and runs periodic operations
 
-use crate::{notifications, sidecar, tray};
+use crate::{email, notifications, sidecar, tray};
 use tauri::{AppHandle, Manager};
 
-/// Start sync and review timers based on user configuration
+/// Start sync, review, and email roundup timers based on user configuration
 pub fn start_timers(app: &AppHandle) {
     start_sync_timer(app);
     start_review_timer(app);
+    start_email_timer(app);
 }
 
 /// Start the periodic sync timer
@@ -85,6 +86,69 @@ fn start_review_timer(app: &AppHandle) {
             }
         }
     });
+}
+
+/// Start the email roundup timer — sends at a specific time of day
+fn start_email_timer(app: &AppHandle) {
+    let config = email::load_email_config(app);
+    if !config.enabled || config.smtp_host.is_empty() || config.to_address.is_empty() {
+        return;
+    }
+
+    let send_time = config.send_time.clone();
+    log::info!("Starting email roundup timer: daily at {}", send_time);
+
+    let handle = app.clone();
+    tauri::async_runtime::spawn(async move {
+        loop {
+            // Calculate duration until next send time
+            let wait = duration_until_time(&send_time);
+            log::info!(
+                "Email roundup: next send in {} minutes",
+                wait.as_secs() / 60
+            );
+
+            tokio::time::sleep(wait).await;
+
+            log::info!("Scheduled email roundup triggered");
+            match email::send_roundup(&handle).await {
+                Ok(summary) => {
+                    log::info!("Email roundup sent: {}", summary);
+                    notifications::notify(&handle, "Roundup Sent", &summary);
+                }
+                Err(e) => {
+                    log::error!("Email roundup failed: {}", e);
+                }
+            }
+
+            // Sleep a bit to avoid firing twice in the same minute
+            tokio::time::sleep(std::time::Duration::from_secs(61)).await;
+        }
+    });
+}
+
+/// Calculate how long to wait until a given HH:MM time today (or tomorrow if past)
+fn duration_until_time(time_str: &str) -> std::time::Duration {
+    let parts: Vec<&str> = time_str.split(':').collect();
+    let target_hour: u32 = parts.first().and_then(|h| h.parse().ok()).unwrap_or(8);
+    let target_min: u32 = parts.get(1).and_then(|m| m.parse().ok()).unwrap_or(0);
+
+    let now = chrono::Local::now();
+    let today_target = now
+        .date_naive()
+        .and_hms_opt(target_hour, target_min, 0)
+        .unwrap_or_else(|| now.naive_local());
+
+    let target = if today_target > now.naive_local() {
+        today_target
+    } else {
+        // Already past today's time, schedule for tomorrow
+        today_target + chrono::Duration::days(1)
+    };
+
+    let diff = target - now.naive_local();
+    diff.to_std()
+        .unwrap_or(std::time::Duration::from_secs(3600))
 }
 
 /// Parse interval strings like "30m", "1h", "4h", "90m" into a Duration.

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1504,6 +1504,46 @@ iframe{width:100%;height:100%;border:none;position:absolute;top:0;left:0}
       }
     }
 
+    // Email roundup settings API
+    if (url.pathname === '/api/email-settings') {
+      if (req.method === 'GET') {
+        const appSettings = loadJsonFile(APP_SETTINGS_PATH);
+        sendJson(res, (appSettings.emailRoundup as Record<string, unknown>) || {
+          enabled: false,
+          smtpHost: '',
+          smtpPort: 587,
+          smtpUser: '',
+          smtpPass: '',
+          useTls: true,
+          fromAddress: '',
+          toAddress: '',
+          sendTime: '08:00',
+          lookbackDays: 1
+        });
+        return;
+      }
+      if (req.method === 'POST') {
+        try {
+          const body = JSON.parse(await readBody(req));
+          const appSettings = loadJsonFile(APP_SETTINGS_PATH);
+          const existing = (appSettings.emailRoundup as Record<string, unknown>) || {};
+          // Merge — only update fields that are present in the request
+          const updated: Record<string, unknown> = { ...existing };
+          const fields = ['enabled', 'smtpHost', 'smtpPort', 'smtpUser', 'smtpPass', 'useTls', 'fromAddress', 'toAddress', 'sendTime', 'lookbackDays'];
+          for (const f of fields) {
+            if (body[f] !== undefined) updated[f] = body[f];
+          }
+          appSettings.emailRoundup = updated;
+          saveJsonFile(APP_SETTINGS_PATH, appSettings);
+          sendJson(res, { ok: true });
+        } catch (err) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Invalid request body' }));
+        }
+        return;
+      }
+    }
+
     // Model catalog for Settings UI
     if (url.pathname === '/api/models' && req.method === 'GET') {
       try {

--- a/viewer/03-settings.js
+++ b/viewer/03-settings.js
@@ -423,6 +423,7 @@ var _settingsTabMap = {
   'settings-voice': 'reading',
   'settings-ai': 'reading',
   'settings-breaks': 'reading',
+  'settings-email': 'general',
   'settings-backup': 'advanced',
   'settings-site-logins': 'advanced',
   'settings-beta': 'advanced',
@@ -506,6 +507,73 @@ function settingsSaveBreakActivity(input) {
 function settingsSaveBeta(enabled) {
   if (enabled) localStorage.setItem('pr-beta-features', 'true');
   else localStorage.removeItem('pr-beta-features');
+}
+
+function settingsEmailToggle(enabled) {
+  var fields = document.getElementById('email-smtp-fields');
+  if (fields) fields.style.display = enabled ? '' : 'none';
+  settingsSaveEmailConfig();
+}
+
+function settingsAutoSaveEmail(input) {
+  settingsSaveEmailConfig().then(function() {
+    if (input && input.parentNode) {
+      var indicator = input.parentNode.querySelector('.save-indicator');
+      if (indicator) indicator.classList.add('visible');
+    }
+  });
+}
+
+function settingsSaveEmailConfig() {
+  var body = {
+    enabled: document.getElementById('sp-email-enabled') ? document.getElementById('sp-email-enabled').checked : false,
+    toAddress: (document.getElementById('sp-email-to') || {}).value || '',
+    fromAddress: (document.getElementById('sp-email-from') || {}).value || '',
+    sendTime: (document.getElementById('sp-email-time') || {}).value || '08:00',
+    lookbackDays: parseInt((document.getElementById('sp-email-lookback') || {}).value || '1', 10),
+    smtpHost: (document.getElementById('sp-email-smtp-host') || {}).value || '',
+    smtpPort: parseInt((document.getElementById('sp-email-smtp-port') || {}).value || '587', 10),
+    smtpUser: (document.getElementById('sp-email-smtp-user') || {}).value || '',
+    smtpPass: (document.getElementById('sp-email-smtp-pass') || {}).value || '',
+    useTls: document.getElementById('sp-email-tls') ? document.getElementById('sp-email-tls').checked : true
+  };
+  return fetch('/api/email-settings', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  }).then(function(r) { return r.json(); });
+}
+
+function settingsTestEmail() {
+  var status = document.getElementById('email-test-status');
+  if (status) status.textContent = 'Sending test email\u2026';
+  // Save first, then send test
+  settingsSaveEmailConfig().then(function() {
+    if (window.__TAURI__) {
+      return window.__TAURI__.core.invoke('cmd_send_test_email');
+    }
+    // Fallback for browser mode — not available without Tauri
+    return Promise.reject('Test email requires the PullRead desktop app');
+  }).then(function(msg) {
+    if (status) { status.textContent = msg || 'Test email sent!'; status.style.color = 'var(--green, #2a9d4a)'; }
+  }).catch(function(err) {
+    if (status) { status.textContent = 'Error: ' + (err || 'Failed to send'); status.style.color = 'var(--red, #c44)'; }
+  });
+}
+
+function settingsSendRoundup() {
+  var status = document.getElementById('email-test-status');
+  if (status) status.textContent = 'Sending roundup\u2026';
+  settingsSaveEmailConfig().then(function() {
+    if (window.__TAURI__) {
+      return window.__TAURI__.core.invoke('cmd_send_roundup');
+    }
+    return Promise.reject('Email roundup requires the PullRead desktop app');
+  }).then(function(msg) {
+    if (status) { status.textContent = msg || 'Roundup sent!'; status.style.color = 'var(--green, #2a9d4a)'; }
+  }).catch(function(err) {
+    if (status) { status.textContent = 'Error: ' + (err || 'Failed to send'); status.style.color = 'var(--red, #c44)'; }
+  });
 }
 
 function settingsAutoSaveSync(input) {
@@ -612,6 +680,13 @@ function showSettingsPage(scrollToSection) {
   html += '<span style="flex-shrink:0;font-size:14px">&#9881;</span>';
   html += '<span>To change notification preferences, go to <strong style="color:var(--fg)">System Settings &rarr; Notifications &rarr; PullRead</strong>. You can enable or disable alerts, banners, and sounds there.</span>';
   html += '</div>';
+  html += '</div>';
+
+  // -- Email Roundup card (loaded async) --
+  html += '<div class="card" id="settings-email">';
+  html += '<div class="card-title">Email Roundup</div>';
+  html += '<div class="card-desc">Get a daily email digest of new articles with links back to PullRead.</div>';
+  html += '<p style="color:var(--muted);font-size:13px">Loading email settings\u2026</p>';
   html += '</div>';
 
 
@@ -944,6 +1019,102 @@ function showSettingsPage(scrollToSection) {
       var sec = document.getElementById('settings-sync');
       if (sec) {
         sec.innerHTML = '<div class="card-title">Sync</div><p style="color:var(--muted);font-size:13px">Could not load sync configuration.</p>';
+      }
+    });
+  }
+
+  // Load Email Roundup settings async
+  if (serverMode) {
+    fetch('/api/email-settings').then(function(r) { return r.json(); }).then(function(data) {
+      var sec = document.getElementById('settings-email');
+      if (!sec) return;
+
+      var h = '<div class="card-title">Email Roundup</div>';
+      h += '<div class="card-desc">Get a daily email digest of new articles with links back to PullRead.</div>';
+
+      // Enable toggle
+      h += '<div class="setting-row">';
+      h += '<div class="setting-label"><label>Enable email roundup</label><div class="setting-desc">Send a daily digest email at a scheduled time</div></div>';
+      h += '<div class="setting-control"><input type="checkbox" id="sp-email-enabled"' + (data.enabled ? ' checked' : '') + ' onchange="settingsEmailToggle(this.checked)" style="width:18px;height:18px;accent-color:var(--link)"></div>';
+      h += '</div>';
+
+      // SMTP fields (collapsible, shown when enabled)
+      h += '<div id="email-smtp-fields" style="' + (data.enabled ? '' : 'display:none') + '">';
+
+      // To address
+      h += '<div class="setting-row">';
+      h += '<div class="setting-label"><label>Send to</label><div class="setting-desc">Email address to receive the roundup</div></div>';
+      h += '<div class="setting-control"><div class="input-wrap"><input type="email" id="sp-email-to" value="' + escapeHtml(data.toAddress || '') + '" placeholder="you@example.com" class="input-field" onfocus="settingsClearSave(this)" onblur="settingsAutoSaveEmail(this)"><span class="save-indicator">\u2713</span></div></div>';
+      h += '</div>';
+
+      // From address
+      h += '<div class="setting-row">';
+      h += '<div class="setting-label"><label>From address</label><div class="setting-desc">Sender address (must match SMTP credentials)</div></div>';
+      h += '<div class="setting-control"><div class="input-wrap"><input type="email" id="sp-email-from" value="' + escapeHtml(data.fromAddress || '') + '" placeholder="pullread@example.com" class="input-field" onfocus="settingsClearSave(this)" onblur="settingsAutoSaveEmail(this)"><span class="save-indicator">\u2713</span></div></div>';
+      h += '</div>';
+
+      // Send time
+      h += '<div class="setting-row">';
+      h += '<div class="setting-label"><label>Send time</label><div class="setting-desc">Time of day to send the roundup</div></div>';
+      h += '<div class="setting-control"><input type="time" id="sp-email-time" value="' + escapeHtml(data.sendTime || '08:00') + '" style="padding:4px 8px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:13px;font-family:inherit" onchange="settingsAutoSaveEmail(this)"></div>';
+      h += '</div>';
+
+      // Lookback days
+      var lookbackDays = data.lookbackDays || 1;
+      var lookbacks = [['1','1 day'],['2','2 days'],['3','3 days'],['7','1 week']];
+      h += '<div class="setting-row">';
+      h += '<div class="setting-label"><label>Include articles from</label><div class="setting-desc">How far back to include articles</div></div>';
+      h += '<div class="setting-control"><div class="pill-group">';
+      for (var li = 0; li < lookbacks.length; li++) {
+        h += '<button class="pill' + (String(lookbackDays) === lookbacks[li][0] ? ' active' : '') + '" data-val="' + lookbacks[li][0] + '" onclick="settingsBtnSelect(this,\'sp-email-lookback\',\'' + lookbacks[li][0] + '\');settingsAutoSaveEmail(this)">' + lookbacks[li][1] + '</button>';
+      }
+      h += '</div><input type="hidden" id="sp-email-lookback" value="' + lookbackDays + '"></div>';
+      h += '</div>';
+
+      // SMTP host
+      h += '<div style="margin-top:16px;padding-top:12px;border-top:1px solid var(--border)">';
+      h += '<div style="font-size:12px;font-weight:600;color:var(--muted);margin-bottom:10px;text-transform:uppercase;letter-spacing:0.05em">SMTP Server</div>';
+      h += '</div>';
+
+      h += '<div class="setting-row">';
+      h += '<div class="setting-label"><label>Host</label></div>';
+      h += '<div class="setting-control"><div class="input-wrap"><input type="text" id="sp-email-smtp-host" value="' + escapeHtml(data.smtpHost || '') + '" placeholder="smtp.gmail.com" class="input-field" onfocus="settingsClearSave(this)" onblur="settingsAutoSaveEmail(this)"><span class="save-indicator">\u2713</span></div></div>';
+      h += '</div>';
+
+      h += '<div class="setting-row">';
+      h += '<div class="setting-label"><label>Port</label></div>';
+      h += '<div class="setting-control"><div class="input-wrap"><input type="number" id="sp-email-smtp-port" value="' + (data.smtpPort || 587) + '" placeholder="587" class="input-field" style="width:80px" onfocus="settingsClearSave(this)" onblur="settingsAutoSaveEmail(this)"><span class="save-indicator">\u2713</span></div></div>';
+      h += '</div>';
+
+      h += '<div class="setting-row">';
+      h += '<div class="setting-label"><label>Username</label></div>';
+      h += '<div class="setting-control"><div class="input-wrap"><input type="text" id="sp-email-smtp-user" value="' + escapeHtml(data.smtpUser || '') + '" placeholder="your-email@gmail.com" class="input-field" onfocus="settingsClearSave(this)" onblur="settingsAutoSaveEmail(this)"><span class="save-indicator">\u2713</span></div></div>';
+      h += '</div>';
+
+      h += '<div class="setting-row">';
+      h += '<div class="setting-label"><label>Password</label><div class="setting-desc">Use an app password for Gmail/Outlook</div></div>';
+      h += '<div class="setting-control"><div class="input-wrap"><input type="password" id="sp-email-smtp-pass" value="' + escapeHtml(data.smtpPass || '') + '" placeholder="App password" class="input-field" onfocus="settingsClearSave(this)" onblur="settingsAutoSaveEmail(this)"><span class="save-indicator">\u2713</span></div></div>';
+      h += '</div>';
+
+      h += '<div class="setting-row">';
+      h += '<div class="setting-label"><label>Use TLS</label><div class="setting-desc">Recommended for most providers</div></div>';
+      h += '<div class="setting-control"><input type="checkbox" id="sp-email-tls"' + (data.useTls !== false ? ' checked' : '') + ' onchange="settingsAutoSaveEmail(this)" style="width:18px;height:18px;accent-color:var(--link)"></div>';
+      h += '</div>';
+
+      // Test & Send buttons
+      h += '<div style="display:flex;gap:10px;flex-wrap:wrap;margin-top:12px">';
+      h += '<button onclick="settingsTestEmail()" style="font-size:13px;padding:6px 16px;background:var(--bg);color:var(--fg);border:1px solid var(--border);border-radius:6px;cursor:pointer;font-family:inherit">Send Test Email</button>';
+      h += '<button onclick="settingsSendRoundup()" style="font-size:13px;padding:6px 16px;background:var(--bg);color:var(--fg);border:1px solid var(--border);border-radius:6px;cursor:pointer;font-family:inherit">Send Roundup Now</button>';
+      h += '</div>';
+      h += '<div id="email-test-status" style="font-size:12px;color:var(--muted);padding-top:8px"></div>';
+
+      h += '</div>'; // end smtp fields
+
+      sec.innerHTML = h;
+    }).catch(function() {
+      var sec = document.getElementById('settings-email');
+      if (sec) {
+        sec.innerHTML = '<div class="card-title">Email Roundup</div><p style="color:var(--muted);font-size:13px">Could not load email settings.</p>';
       }
     });
   }


### PR DESCRIPTION
Summary
Adds a new Email Roundup feature that sends a daily HTML digest of recently synced articles to a configured email address. The digest includes article titles, sources, and authors, with each article linking through the existing <pullread.com/link> redirect page so links work reliably in all email clients.
	∙	New Rust email module using the lettre crate for SMTP delivery (TLS and STARTTLS)
	∙	Scheduled daily timer that fires at a user-configured time of day
	∙	Full settings UI in Settings > General > Email Roundup with auto-save
	∙	GET/POST /api/email-settings endpoint for persisting configuration
	∙	“Send Test Email” and “Send Roundup Now” buttons for verifying setup
How it works
	1.	User enables the roundup in Settings and configures SMTP credentials, recipient, and send time
	2.	At the scheduled time each day, the app fetches recent articles from the viewer API
	3.	An HTML email is built with article cards linking through <https://pullread.com/link?url=...&title=...>
	4.	The email is sent via SMTP from the Rust backend — no external services needed
Article links use the existing fallback redirect page rather than raw pullread:// deep links, since email clients strip or block custom URL schemes. The redirect page attempts the deep link automatically and falls back to showing the original article with an “Open in Pull Read” button. 


Test plan
	∙	Configure SMTP credentials in Settings > General > Email Roundup
	∙	Send a test email and verify delivery
	∙	Send a roundup and verify article links go through <pullread.com/link>
	∙	Verify clicking a link from the email opens the article in PullRead (or shows fallback)
	∙	Toggle enable/disable and confirm SMTP fields hide/show
	∙	Confirm settings persist across app restart
	∙	Verify scheduled timer fires at the configured time (check logs)