### PR TITLE
Release 0.4.9 — Restore tray menu on left-click

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pullread",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Sync Drafty bookmarks to markdown files",
   "main": "src/index.ts",
   "scripts": {

--- a/site/releases.html
+++ b/site/releases.html
@@ -133,6 +133,18 @@
 <!-- Releases -->
 <div class="releases">
 
+  <div class="release-card reveal" id="v0.4.9">
+    <div class="release-header">
+      <span class="release-version">0.4.9</span>
+      <span class="release-subtitle">"Menu Please"</span>
+    </div>
+    <div class="release-date">April 2026</div>
+    <ul>
+      <li>Fixed the menu bar icon &mdash; clicking it now opens the menu again (Sync, View, Settings, Check for Updates, Quit). A regression in 0.4.8 made it open the viewer directly with no way to reach the menu.</li>
+      <li>The Dock icon still opens the viewer on click, as in 0.4.8.</li>
+    </ul>
+  </div>
+
   <div class="release-card reveal" id="v0.4.8">
     <div class="release-header">
       <span class="release-version">0.4.8</span>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "pullread"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "chrono",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pullread"
-version = "0.4.8"
+version = "0.4.9"
 description = "Sync articles from RSS feeds, bookmarks, and newsletters to searchable markdown files"
 authors = ["PullRead"]
 edition = "2021"

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -5,7 +5,7 @@ use crate::{commands, notifications, sidecar};
 use std::sync::Mutex;
 use tauri::{
     menu::{Menu, MenuItem, PredefinedMenuItem},
-    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
+    tray::TrayIconBuilder,
     AppHandle, Manager,
 };
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
@@ -54,7 +54,7 @@ pub fn create_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         .icon_as_template(true)
         .tooltip("Pull Read")
         .menu(&menu)
-        .show_menu_on_left_click(false)
+        .show_menu_on_left_click(true)
         .on_menu_event(|app, event| {
             let id = event.id().as_ref();
             let handle = app.clone();
@@ -85,19 +85,6 @@ pub fn create_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                     handle.exit(0);
                 }
                 _ => {}
-            }
-        })
-        .on_tray_icon_event(|tray, event| {
-            if let TrayIconEvent::Click {
-                button: MouseButton::Left,
-                button_state: MouseButtonState::Up,
-                ..
-            } = event
-            {
-                let handle = tray.app_handle().clone();
-                tauri::async_runtime::spawn(async move {
-                    let _ = commands::open_viewer_inner(&handle).await;
-                });
             }
         })
         .build(app)?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pull Read",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "identifier": "com.pullread.desktop",
   "build": {
     "beforeBuildCommand": "bun run scripts/embed-viewer.ts",

--- a/viewer/03-settings.js
+++ b/viewer/03-settings.js
@@ -957,7 +957,7 @@ function showSettingsPage(scrollToSection) {
   html += '</div>';
   html += '<div style="display:flex;gap:12px;flex-wrap:wrap;padding:8px 0">';
   html += '<a href="https://pullread.com" target="_blank" rel="noopener" style="font-size:13px;color:var(--link)">pullread.com</a>';
-  html += '<a href="#" onclick="prOpenExternal(\'https://pullread.com/releases#v\' + (window._prCurrentVersion || \'0.4.8\'));return false" style="font-size:13px;color:var(--link)">What\'s New</a>';
+  html += '<a href="#" onclick="prOpenExternal(\'https://pullread.com/releases#v\' + (window._prCurrentVersion || \'0.4.9\'));return false" style="font-size:13px;color:var(--link)">What\'s New</a>';
   html += '<a href="/api/log" target="_blank" style="font-size:13px;color:var(--link)">View Logs</a>';
   html += '<button style="font-size:13px;padding:6px 16px;background:var(--bg);color:var(--fg);border:1px solid var(--border);border-radius:6px;cursor:pointer;font-family:inherit" onclick="showTour()">Show Tour</button>';
   html += '</div>';


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced in v0.4.8: clicking the menu bar (tray) icon opened the viewer directly and left no way to reach Sync / Settings / Check for Updates / Quit from the menu.

## Fix

`src-tauri/src/tray.rs`: restore `show_menu_on_left_click(true)` and remove the left-click handler that opened the viewer. Dock icon click still opens the viewer via the `RunEvent::Reopen` handler in `lib.rs` (unchanged).

## Test plan

- [x] `cargo check` in `src-tauri/` — clean (one unrelated pre-existing dead-code warning)
- [x] `bun test` — 533 pass, 131 pre-existing baseline fails
- [x] `bun run scripts/embed-viewer.ts` — bundle regenerated with 0.4.9 fallback
- [ ] CI green on this PR
- [ ] After release: click menu bar icon → menu appears
- [ ] After release: click Dock icon → viewer opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)