### PR TITLE
Make releases cuttable from GitHub with post-publish verification

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -254,6 +254,49 @@ jobs:
           gh release edit "$TAG" --draft=false
           echo "Published release $TAG"
 
+  # Fail loudly if the published release is missing assets or mismatched —
+  # a release that "succeeded" but shipped nothing is worse than a red build.
+  verify-release:
+    needs: publish-updater
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Verify published release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          VERSION="${TAG#v}"
+
+          INFO=$(gh release view "$TAG" --repo "${{ github.repository }}" --json isDraft,isPrerelease,assets)
+          echo "$INFO" | jq .
+
+          if [ "$(echo "$INFO" | jq -r '.isDraft')" != "false" ]; then
+            echo "::error::Release $TAG is still a draft"
+            exit 1
+          fi
+
+          DMG_COUNT=$(echo "$INFO" | jq '[.assets[].name | select(endswith(".dmg"))] | length')
+          if [ "$DMG_COUNT" -lt 2 ]; then
+            echo "::error::Expected 2 DMGs (ARM64 + Intel), found $DMG_COUNT"
+            exit 1
+          fi
+
+          if ! echo "$INFO" | jq -e '.assets[] | select(.name == "latest.json")' > /dev/null; then
+            echo "::error::latest.json missing from release — auto-updater will not work"
+            exit 1
+          fi
+
+          MANIFEST_VERSION=$(gh release download "$TAG" --repo "${{ github.repository }}" -p latest.json -O - | jq -r '.version')
+          if [ "$MANIFEST_VERSION" != "$VERSION" ]; then
+            echo "::error::latest.json version is $MANIFEST_VERSION but tag is $VERSION"
+            exit 1
+          fi
+
+          echo "Release $TAG verified: published, $DMG_COUNT DMGs, latest.json at $MANIFEST_VERSION"
+
   # Auto-update "latest" pre-release on every push to main
   latest-release:
     needs: build

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,69 @@
+# ABOUTME: Cuts a release from the GitHub UI/API — validates, tags, and dispatches the release build
+# ABOUTME: Removes the manual local tag-push step so releases can't stall half-finished
+
+name: Cut Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. 0.4.10) — must match package.json on main'
+        required: true
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  cut:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Validate version
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid version '$VERSION' (expected X.Y.Z)"
+            exit 1
+          fi
+          PKG=$(node -p "require('./package.json').version")
+          if [ "$PKG" != "$VERSION" ]; then
+            echo "::error::package.json on main is $PKG, not $VERSION — run bump-version and merge first"
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/v$VERSION" > /dev/null 2>&1; then
+            echo "::error::Tag v$VERSION already exists"
+            exit 1
+          fi
+
+      - name: Verify latest main build succeeded
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CONCLUSION=$(gh run list --workflow build-tauri.yml --branch main --event push --limit 1 --json conclusion --jq '.[0].conclusion')
+          if [ "$CONCLUSION" != "success" ]; then
+            echo "::error::Latest main build concluded '$CONCLUSION' — fix main before releasing"
+            exit 1
+          fi
+
+      - name: Create and push tag
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+
+      # A tag pushed with GITHUB_TOKEN does not fire on:push workflows
+      # (recursion prevention), so dispatch the release build explicitly.
+      - name: Dispatch release build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          gh workflow run build-tauri.yml --ref "refs/tags/v$VERSION"
+          echo "Release build dispatched for v$VERSION — watch the Build Tauri App workflow"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -110,18 +110,21 @@ laptop) and some environments can't push tags at all.
 
 ### 8. Wait for release CI
 
-The release build runs four jobs:
+The tag build (`Build Tauri App`) runs three jobs:
 
 | Job | What it does |
 |-----|-------------|
 | **build** (matrix) | Builds ARM64 + Intel sidecars, signs, notarizes, creates draft release with DMGs |
 | **publish-updater** | Signs update bundles, builds `latest.json`, publishes the release (marks as non-draft) |
 | **verify-release** | Fails loudly if the release is still draft, missing a DMG, missing `latest.json`, or the manifest version mismatches the tag |
-| **deploy-site** | Deploys pullread.com to GitHub Pages |
 
 Monitor with `gh run list --limit 5`. The whole pipeline takes ~12 minutes.
 
 **There is no manual publish step.** The `publish-updater` job calls `gh release edit --draft=false` automatically, and `verify-release` confirms the result.
+
+The site (pullread.com/releases) is **not** deployed by the tag build — `deploy-site.yml`
+runs on every push to `main`, so the release notes go live when the version-bump PR
+merges (step 5), before you tag. Nothing extra to do.
 
 ### 9. Verify
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,11 +14,25 @@ npm run typecheck && npm test && npm run test:bun   # tsc + jest suite + the two
 # 3. Update site/releases.html and _prCurrentVersion fallback
 # 4. Commit, push, create PR → wait for CI ✓
 # 5. Merge PR to main → wait for CI ✓
-# 6. Tag
-git checkout main && git pull
-git tag vX.Y.Z && git push origin vX.Y.Z
-# CI builds, signs, notarizes, and publishes — no manual steps after tagging
+# 6. Test the pre-release build from the rolling "latest" prerelease (see below)
+# 7. Cut the release: Actions → "Cut Release" → Run workflow → enter X.Y.Z
+#    (or: gh workflow run cut-release.yml -f version=X.Y.Z)
+# CI validates, tags, builds, signs, notarizes, publishes, and verifies — no manual steps after
 ```
+
+## Testing a pre-release before cutting
+
+Every green push to main refreshes the rolling **`latest` prerelease** with signed,
+notarized DMGs built from that exact commit. Download and test the real build
+**before** tagging:
+
+- Apple Silicon: <https://github.com/shellen/pullread/releases/download/latest/PullRead.dmg>
+- Intel: <https://github.com/shellen/pullread/releases/download/latest/PullRead_Intel.dmg>
+
+The release page (<https://github.com/shellen/pullread/releases/tag/latest>) shows
+which commit the build came from — confirm it matches your merge before testing.
+PR builds also upload `.dmg`/`.app` artifacts to their workflow runs (30-day
+retention) if you need to test before merging.
 
 ## Step by Step
 
@@ -73,30 +87,45 @@ gh pr merge --merge
 
 **Wait for the main branch build to succeed.** This ensures the `latest` rolling build is healthy before tagging. Check with `gh run list --limit 3`.
 
-### 6. Tag the release
+### 6. Test the pre-release build
+
+Download the DMG from the rolling `latest` prerelease (see "Testing a pre-release"
+above), confirm its commit matches your merge, and smoke-test the release-critical
+paths before tagging.
+
+### 7. Cut the release
+
+Go to **Actions → Cut Release → Run workflow**, enter the version (e.g. `0.4.10`),
+and run. Or from any machine with `gh`:
 
 ```bash
-git checkout main && git pull
-git tag vX.Y.Z && git push origin vX.Y.Z
+gh workflow run cut-release.yml -f version=X.Y.Z
 ```
 
-### 7. Wait for release CI
+The workflow refuses to run if the version doesn't match `package.json` on main,
+the tag already exists, or the latest main build is red — then it creates the tag
+and dispatches the release build. **Do not tag manually** — local tag pushes are
+easy to forget (a release once stalled for hours because the tag never left a
+laptop) and some environments can't push tags at all.
 
-The tag push triggers three jobs:
+### 8. Wait for release CI
+
+The release build runs four jobs:
 
 | Job | What it does |
 |-----|-------------|
 | **build** (matrix) | Builds ARM64 + Intel sidecars, signs, notarizes, creates draft release with DMGs |
 | **publish-updater** | Signs update bundles, builds `latest.json`, publishes the release (marks as non-draft) |
+| **verify-release** | Fails loudly if the release is still draft, missing a DMG, missing `latest.json`, or the manifest version mismatches the tag |
 | **deploy-site** | Deploys pullread.com to GitHub Pages |
 
 Monitor with `gh run list --limit 5`. The whole pipeline takes ~12 minutes.
 
-**There is no manual publish step.** The `publish-updater` job calls `gh release edit --draft=false` automatically.
+**There is no manual publish step.** The `publish-updater` job calls `gh release edit --draft=false` automatically, and `verify-release` confirms the result.
 
-### 8. Verify
+### 9. Verify
 
-- [ ] `gh release view vX.Y.Z` shows both DMGs + `latest.json`
+- [ ] The **verify-release** job is green (checks DMGs + `latest.json` + version automatically)
 - [ ] Auto-updater: open an older version of Pull Read, check for update prompt
 - [ ] Site: visit pullread.com/releases and verify the new version appears
 


### PR DESCRIPTION
## Why

The v0.4.10 release stalled because tagging was a manual, local step — and some environments (like branch-scoped remote sessions) can't push tags at all. Nothing surfaced the failure; the release simply didn't appear on GitHub.

## What

- **`cut-release.yml`** — releases are now cut from GitHub itself: **Actions → Cut Release → Run workflow → version**. It refuses to run unless the version matches `package.json` on main, the tag is new, and the latest main build is green. Then it creates the tag and dispatches the release build. (A `GITHUB_TOKEN` tag push doesn't fire `on: push` workflows, hence the explicit dispatch.)
- **`verify-release` job** in `build-tauri.yml` — after publish, fails loudly if the release is still a draft, missing either DMG, missing `latest.json`, or the manifest version mismatches the tag. A release that "succeeded" but shipped nothing is now a red build, not a silent gap.
- **RELEASING.md** — documents the new flow, forbids manual tagging, and adds a **"Testing a pre-release"** section: every green main push refreshes the rolling `latest` prerelease with signed, notarized DMGs downloadable *before* tagging.

## After merging

Cutting v0.4.10 is one action: **Actions → Cut Release → `0.4.10`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCSkRmoCdygieNrSfn5FYz

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCSkRmoCdygieNrSfn5FYz)_