### PR TITLE
Redesign roundup email: scoring, ranking, and AI disclosure

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -12,7 +12,7 @@ on:
       - 'src-tauri/**'
       - 'scripts/**'
       - 'package.json'
-      - 'bun.lockb'
+      - 'bun.lock'
       - 'viewer.html'
       - '.github/workflows/build-tauri.yml'
   pull_request:
@@ -22,7 +22,7 @@ on:
       - 'src-tauri/**'
       - 'scripts/**'
       - 'package.json'
-      - 'bun.lockb'
+      - 'bun.lock'
       - 'viewer.html'
       - '.github/workflows/build-tauri.yml'
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ dist/
 src/viewer-html.ts
 src-tauri/resources/
 
+# Local rundown email preview (written by `preview-rundown`)
+rundown-preview.html
+
 # Environment
 .env
 .dev.vars

--- a/site/releases.html
+++ b/site/releases.html
@@ -138,7 +138,7 @@
       <span class="release-version">0.4.10</span>
       <span class="release-subtitle">"Hot Off The Press"</span>
     </div>
-    <div class="release-date">June 2026</div>
+    <div class="release-date">July 2026</div>
     <ul>
       <li>The daily email Rundown now writes a fresh editorial summary from your actual articles each day &mdash; previously it could repeat the same generic blurb regardless of what you&rsquo;d saved.</li>
       <li>Article titles with brackets display correctly &mdash; titles like Daring Fireball&rsquo;s &ldquo;[Sponsor]&rdquo; posts no longer lose their opening bracket in the reader.</li>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "pullread"
-version = "0.4.8"
+version = "0.4.10"
 dependencies = [
  "chrono",
  "dirs 6.0.0",

--- a/src/email.test.ts
+++ b/src/email.test.ts
@@ -137,17 +137,17 @@ describe('buildRoundupHtml', () => {
     expect(html).toContain('My RSS Feed');
   });
 
-  test('headline opens in Pull Read (matching the in-app rundown), with the source as a secondary link', () => {
-    const html = buildRoundupHtml([article({ url: 'https://example.com/article?id=1' })], 1);
-    // Primary action: open in the Pull Read reader (deep link), like tapping a headline in-app.
-    expect(html).toContain('pullread.com/link');
+  test('headline links to the source; Open in Pull Read is a desktop-only extra', () => {
+    const url = 'https://example.com/article?id=1';
+    const html = buildRoundupHtml([article({ url })], 1);
+    // The headline links straight to the original source, so it works on any device.
+    expect(html).toContain(`<a href="${url}"`);
+    // Open in Pull Read is still offered, but only on desktop (no Pull Read on mobile yet).
     expect(html).toContain('Open in Pull Read');
-    // The headline itself links to Pull Read, not straight to the publisher.
-    const prLink = `https://pullread.com/link?url=${encodeURIComponent('https://example.com/article?id=1')}`;
-    expect(html).toContain(prLink);
-    // Secondary action: the original source is still one click away.
-    expect(html).toContain('Read the original');
-    expect(html).toContain('https://example.com/article?id=1');
+    expect(html).toContain('pullread.com/link');
+    expect(html).toContain('class="pr-desktop-only"');
+    // The media query that hides it on small screens is present.
+    expect(html).toContain('.pr-desktop-only{display:none');
   });
 
   test('escapes HTML in article titles', () => {
@@ -222,15 +222,39 @@ describe('buildRoundupHtml', () => {
     expect(html).toContain('Pull Read');
   });
 
-  test('renders AI summary when provided', () => {
+  test('renders the AI intro as a plain newsletter lede (no bounding box)', () => {
     const html = buildRoundupHtml([article()], 1, 'AI is reshaping how we read and write.');
     expect(html).toContain('AI is reshaping how we read and write.');
-    expect(html).toContain('border-left:3px solid #b45535');
+    // No boxed callout — the intro sits on the card like a lede.
+    expect(html).not.toContain('border-left:3px solid #b45535');
+    expect(html).not.toContain('background:#faf8f6');
   });
 
   test('renders without summary when null', () => {
     const html = buildRoundupHtml([article()], 1, null);
-    expect(html).not.toContain('border-left:3px solid #b45535');
+    expect(html).not.toContain('Summary by');
+  });
+
+  test('links story references in the intro to the matching article', () => {
+    const arts = [
+      article({ title: 'EU forces Google', url: 'https://a.com/eu' }),
+      article({ title: 'Self-parking EV', url: 'https://b.com/ev' }),
+    ];
+    const summary = 'Regulators moved on {{Google’s search data|1}} while carmakers bet on {{a self-parking EV|2}}.';
+    const html = buildRoundupHtml(arts, 1, summary);
+    expect(html).toContain('<a href="https://a.com/eu"');
+    expect(html).toContain('<a href="https://b.com/ev"');
+    expect(html).toContain('a self-parking EV');
+    // The raw {{...|n}} markers never leak into the output.
+    expect(html).not.toContain('{{');
+    expect(html).not.toContain('|1}}');
+  });
+
+  test('strips citation markers that reference a missing story, keeping the words', () => {
+    const html = buildRoundupHtml([article({ url: 'https://a.com/x' })], 1, 'A claim about {{something big|9}} today.');
+    expect(html).toContain('something big');
+    expect(html).not.toContain('{{');
+    expect(html).not.toContain('|9');
   });
 
   test('splits the intro into paragraphs on blank lines', () => {

--- a/src/email.test.ts
+++ b/src/email.test.ts
@@ -137,17 +137,21 @@ describe('buildRoundupHtml', () => {
     expect(html).toContain('My RSS Feed');
   });
 
-  test('headline links to the source; Open in Pull Read is a desktop-only extra', () => {
+  test('headline is the only link (to the source); no per-item Pull Read CTA', () => {
     const url = 'https://example.com/article?id=1';
-    const html = buildRoundupHtml([article({ url })], 1);
-    // The headline links straight to the original source, so it works on any device.
+    const html = buildRoundupHtml([article({ url, image: 'https://example.com/p.jpg', excerpt: 'x' })], 1);
+    // The headline links straight to the source, so it works on any device.
     expect(html).toContain(`<a href="${url}"`);
-    // Open in Pull Read is still offered, but only on desktop (no Pull Read on mobile yet).
-    expect(html).toContain('Open in Pull Read');
-    expect(html).toContain('pullread.com/link');
-    expect(html).toContain('class="pr-desktop-only"');
-    // The media query that hides it on small screens is present.
-    expect(html).toContain('.pr-desktop-only{display:none');
+    // No repeated "Open in Pull Read" label / deep link on every item.
+    expect(html).not.toContain('Open in Pull Read');
+    expect(html).not.toContain('pullread.com/link');
+  });
+
+  test('hero image/text stack on mobile via responsive classes', () => {
+    const html = buildRoundupHtml([article({ image: 'https://example.com/p.jpg', excerpt: 'x' })], 1);
+    expect(html).toContain('class="hero-cell hero-img"');
+    // The media query that stacks the cells on small screens is present.
+    expect(html).toContain('.hero-cell{display:block');
   });
 
   test('escapes HTML in article titles', () => {

--- a/src/email.test.ts
+++ b/src/email.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Tests for the email roundup module
 // ABOUTME: Covers HTML generation, escaping, provider resolution, curation, summary, and send logic
 
-import { escapeHtml, buildRoundupHtml, sendTestEmail, sendRoundup, resolveSmtpConfig, SMTP_PROVIDERS, curateArticles, generateRoundupSummary, buildRoundup, filterByLookback } from './email';
+import { escapeHtml, buildRoundupHtml, sendTestEmail, sendRoundup, resolveSmtpConfig, SMTP_PROVIDERS, curateArticles, generateRoundupSummary, buildRoundup, filterByLookback, formatModelDisclosure } from './email';
 import type { EmailConfig, ArticleMeta } from './email';
 
 jest.mock('./summarizer', () => ({
@@ -137,11 +137,17 @@ describe('buildRoundupHtml', () => {
     expect(html).toContain('My RSS Feed');
   });
 
-  test('includes both PullRead and direct links', () => {
+  test('headline opens in Pull Read (matching the in-app rundown), with the source as a secondary link', () => {
     const html = buildRoundupHtml([article({ url: 'https://example.com/article?id=1' })], 1);
+    // Primary action: open in the Pull Read reader (deep link), like tapping a headline in-app.
     expect(html).toContain('pullread.com/link');
     expect(html).toContain('Open in Pull Read');
-    expect(html).toContain('Read &rarr;');
+    // The headline itself links to Pull Read, not straight to the publisher.
+    const prLink = `https://pullread.com/link?url=${encodeURIComponent('https://example.com/article?id=1')}`;
+    expect(html).toContain(prLink);
+    // Secondary action: the original source is still one click away.
+    expect(html).toContain('Read the original');
+    expect(html).toContain('https://example.com/article?id=1');
   });
 
   test('escapes HTML in article titles', () => {
@@ -184,7 +190,7 @@ describe('buildRoundupHtml', () => {
     })], 1);
     expect(html).toContain('https://example.com/photo.jpg');
     expect(html).toContain('A fascinating look at something.');
-    expect(html).toContain('width="130"');
+    expect(html).toContain('width="140"');
   });
 
   test('renders hero without image gracefully', () => {
@@ -194,7 +200,7 @@ describe('buildRoundupHtml', () => {
     })], 1);
     expect(html).toContain('No image here.');
     // Should not contain an article thumbnail (header image is fine)
-    expect(html).not.toContain('width="130"');
+    expect(html).not.toContain('width="140"');
   });
 
   test('truncates long excerpts', () => {
@@ -225,6 +231,28 @@ describe('buildRoundupHtml', () => {
   test('renders without summary when null', () => {
     const html = buildRoundupHtml([article()], 1, null);
     expect(html).not.toContain('border-left:3px solid #b45535');
+  });
+
+  test('splits the intro into paragraphs on blank lines', () => {
+    const summary = 'First para, the throughline.\n\nSecond para, the tension.\n\nThird para, the payoff.';
+    const html = buildRoundupHtml([article()], 1, summary);
+    // Each paragraph becomes its own <p> so the note reads like a briefing.
+    const paraCount = (html.match(/<p style="margin:0 0 [^"]*;font-size:16px/g) || []).length;
+    expect(paraCount).toBe(3);
+    expect(html).toContain('First para, the throughline.');
+    expect(html).toContain('Second para, the tension.');
+    expect(html).toContain('Third para, the payoff.');
+  });
+
+  test('discloses the AI model that wrote the intro when provided', () => {
+    const html = buildRoundupHtml([article()], 1, 'A sharp little briefing.', 'Claude Haiku 4.5');
+    expect(html).toContain('This intro was written by');
+    expect(html).toContain('Claude Haiku 4.5');
+  });
+
+  test('omits the AI disclosure when no model is provided', () => {
+    const html = buildRoundupHtml([article()], 1, 'A sharp little briefing.');
+    expect(html).not.toContain('This intro was written by');
   });
 });
 
@@ -360,7 +388,8 @@ describe('generateRoundupSummary', () => {
     ];
     const result = await generateRoundupSummary(articles);
 
-    expect(result).toBe('A fresh, article-aware blurb.');
+    // Returns the text plus the model/provider that produced it, for AI disclosure.
+    expect(result).toEqual({ text: 'A fresh, article-aware blurb.', model: 'gpt-5', provider: 'openai' });
     // Must route through promptLLM, which sends the prompt verbatim — NOT summarizeText,
     // which would prepend "Summarize this article…" and yield a near-static blurb.
     expect(mockPromptLLM).toHaveBeenCalledTimes(1);
@@ -370,6 +399,8 @@ describe('generateRoundupSummary', () => {
     expect(prompt).toContain('New transit plan');
     // The roundup instructions are present as instructions.
     expect(prompt).toContain('opening note for a daily reading rundown');
+    // The prompt asks for real paragraph structure.
+    expect(prompt).toContain('SHORT paragraphs');
   });
 
   test('returns null when the model yields empty text', async () => {
@@ -421,7 +452,7 @@ describe('buildRoundup', () => {
 
   const cfg = (): EmailConfig => ({ ...baseConfig });
 
-  test('renders article titles and the editorial note into the HTML', async () => {
+  test('renders article titles and the editorial note into the HTML, and discloses the model', async () => {
     mockLoadLLMConfig.mockReturnValue({ provider: 'openai', apiKey: 'k', model: 'gpt-5' });
     mockPromptLLM.mockResolvedValue({ text: 'A fresh editorial note.', model: 'gpt-5' });
 
@@ -432,10 +463,14 @@ describe('buildRoundup', () => {
     const result = await buildRoundup(cfg(), async () => articles);
 
     expect(result.summary).toBe('A fresh editorial note.');
+    expect(result.summaryModel).toBe('GPT-5');
     expect(result.articles).toHaveLength(2);
     expect(result.html).toContain('Quantum chips ship');
     expect(result.html).toContain('New transit plan');
     expect(result.html).toContain('A fresh editorial note.');
+    // The AI-written intro discloses which model produced it.
+    expect(result.html).toContain('This intro was written by');
+    expect(result.html).toContain('GPT-5');
     expect(result.subject).toContain('The Pull Read Rundown');
   });
 
@@ -444,7 +479,40 @@ describe('buildRoundup', () => {
     const result = await buildRoundup(cfg(), async () => articles);
 
     expect(result.summary).toBeNull();
+    expect(result.summaryModel).toBeNull();
     expect(result.html).toContain('Solo story');
+    expect(result.html).not.toContain('This intro was written by');
     expect(mockPromptLLM).not.toHaveBeenCalled();
+  });
+});
+
+describe('formatModelDisclosure', () => {
+  test('formats Anthropic Claude model ids', () => {
+    expect(formatModelDisclosure('anthropic', 'claude-haiku-4-5-20251001')).toBe('Claude Haiku 4.5');
+    expect(formatModelDisclosure('anthropic', 'claude-opus-4-7')).toBe('Claude Opus 4.7');
+  });
+
+  test('formats OpenAI model ids', () => {
+    expect(formatModelDisclosure('openai', 'gpt-5')).toBe('GPT-5');
+    expect(formatModelDisclosure('openai', 'gpt-5-mini')).toBe('GPT-5 mini');
+    expect(formatModelDisclosure('openai', 'gpt-4.1-nano')).toBe('GPT-4.1 nano');
+  });
+
+  test('formats Gemini model ids', () => {
+    expect(formatModelDisclosure('gemini', 'gemini-2.5-flash-lite')).toBe('Gemini 2.5 Flash Lite');
+    expect(formatModelDisclosure('gemini', 'gemini-2.5-pro')).toBe('Gemini 2.5 Pro');
+  });
+
+  test('names Apple Intelligence as on-device', () => {
+    expect(formatModelDisclosure('apple', 'on-device')).toBe('Apple Intelligence (on-device)');
+    expect(formatModelDisclosure('apple', 'apple-on-device')).toBe('Apple Intelligence (on-device)');
+  });
+
+  test('keeps the OpenRouter routing visible', () => {
+    expect(formatModelDisclosure('openrouter', 'anthropic/claude-haiku-4.5')).toBe('Claude Haiku 4.5 (via OpenRouter)');
+  });
+
+  test('falls back to a clean title-case name for unknown models', () => {
+    expect(formatModelDisclosure('openrouter', 'meta-llama/llama-3.3-70b-instruct:free')).toBe('Llama 3.3 70b Instruct (via OpenRouter)');
   });
 });

--- a/src/email.test.ts
+++ b/src/email.test.ts
@@ -4,6 +4,15 @@
 import { escapeHtml, buildRoundupHtml, sendTestEmail, sendRoundup, resolveSmtpConfig, SMTP_PROVIDERS, curateArticles, generateRoundupSummary, buildRoundup, filterByLookback, formatSummaryCredit, scoreArticle, groupByCategory } from './email';
 import type { EmailConfig, ArticleMeta } from './email';
 
+jest.mock('nodemailer', () => ({
+  // No test should ever open a real socket — a connect attempt in offline
+  // environments hangs until the Jest timeout (issue #106). Send paths that
+  // pass config validation reject with this marker error instead.
+  createTransport: jest.fn(() => ({
+    sendMail: jest.fn(() => Promise.reject(new Error('mock transport: network disabled in tests'))),
+  })),
+}));
+
 jest.mock('./summarizer', () => ({
   // Default: no LLM configured, so generateRoundupSummary short-circuits to null.
   // Individual tests override these mocks as needed.
@@ -548,12 +557,14 @@ describe('sendTestEmail', () => {
   });
 
   test('does not throw for gmail provider with empty smtpHost', async () => {
+    // Gmail's host comes from the provider preset, so validation passes and
+    // the call proceeds to the (mocked) transport — no real socket.
     await expect(sendTestEmail({
       ...baseConfig,
       smtpProvider: 'gmail',
       smtpHost: '',
       smtpPort: 99999,
-    })).rejects.not.toThrow('missing SMTP host or recipient');
+    })).rejects.toThrow('mock transport: network disabled in tests');
   });
 });
 

--- a/src/email.test.ts
+++ b/src/email.test.ts
@@ -254,6 +254,114 @@ describe('buildRoundupHtml', () => {
     expect(html).not.toContain('|1}}');
   });
 
+  test('links plain title mentions when the model skips the {{…|N}} markers', () => {
+    // Apple Intelligence ignores the marker convention but names stories by
+    // title — the renderer links those mentions, same as the in-app briefing.
+    const arts = [
+      article({ title: 'Apple Does Fusion', url: 'https://a.com/fusion' }),
+      article({ title: 'EU Fines Google', url: 'https://b.com/eu' }),
+    ];
+    const summary = 'The article "Apple Does Fusion" digs into fusion energy, while "EU fines Google" covers the antitrust ruling.';
+    const html = buildRoundupHtml(arts, 1, summary);
+    expect(html).toContain('<a href="https://a.com/fusion"');
+    // Case-insensitive match, original casing preserved in the link text.
+    expect(html).toContain('<a href="https://b.com/eu"');
+    expect(html).toContain('>EU fines Google</a>');
+  });
+
+  test('trusts the phrase over the number when a marker names a different story', () => {
+    // Regression: Apple Intelligence renumbered its mentions 1, 2, 3… so every
+    // marker pointed at the wrong article. When the phrase IS a story's title,
+    // the words win over the number.
+    const arts = [
+      article({ title: 'EU Fines Google', url: 'https://a.com/eu' }),
+      article({ title: 'Quake Strikes Border Region', url: 'https://b.com/quake' }),
+    ];
+    const summary = 'Big day: {{Quake Strikes Border Region|1}} and more.';
+    const html = buildRoundupHtml(arts, 1, summary);
+    expect(html).toContain('<a href="https://b.com/quake" style="color:#b45535;text-decoration:underline');
+    expect(html).not.toContain('<a href="https://a.com/eu" style="color:#b45535;text-decoration:underline');
+  });
+
+  test('links a quoted, shortened title mention to the right story', () => {
+    // Small models quote titles but drop the "| Show Name" suffix.
+    const arts = [article({
+      title: "Analyzing Portugal's Devastating Wildfire (Full Episode) | Witness to Disaster",
+      url: 'https://y.com/wildfire',
+    })];
+    const summary = 'The documentary "Analyzing Portugal’s Devastating Wildfire" explores the largest fire in the country’s history.';
+    const html = buildRoundupHtml(arts, 1, summary);
+    expect(html).toContain('<a href="https://y.com/wildfire" style="color:#b45535;text-decoration:underline');
+  });
+
+  test('links an unquoted word run matching the start of a long title', () => {
+    const arts = [article({
+      title: 'Nordstrom Anniversary Sale 2026 – Picks for Men | Dapper',
+      url: 'https://d.com/nordstrom',
+    })];
+    const summary = 'Meanwhile the Nordstrom Anniversary Sale 2026 promises a shopping paradise.';
+    const html = buildRoundupHtml(arts, 1, summary);
+    expect(html).toContain('<a href="https://d.com/nordstrom" style="color:#b45535;text-decoration:underline');
+    expect(html).toContain('>Nordstrom Anniversary Sale 2026</a>');
+  });
+
+  test('does not produce a link ending on a stopword from a partial title match', () => {
+    const arts = [article({ title: 'Jake Johnson - “The Dink” | The Daily Show', url: 'https://y.com/dink' })];
+    const summary = 'Jake Johnson, the beloved actor, discusses his new project.';
+    const html = buildRoundupHtml(arts, 1, summary);
+    expect(html).not.toContain('<a href="https://y.com/dink" style="color:#b45535;text-decoration:underline');
+  });
+
+  test('does not link a short common word run', () => {
+    const arts = [article({ title: 'How to Fix Your Sleep | Wired', url: 'https://w.com/sleep' })];
+    const summary = 'Someone explains how to fix the power grid this decade.';
+    const html = buildRoundupHtml(arts, 1, summary);
+    expect(html).not.toContain('<a href="https://w.com/sleep" style="color:#b45535;text-decoration:underline');
+  });
+
+  test('does not link a short generic quoted fragment shared by many titles', () => {
+    const arts = [article({
+      title: 'Sports War: Norway Fan Hates Rowing | The Daily Show',
+      url: 'https://y.com/sports',
+    })];
+    const summary = 'Michael Kosta on "The Daily Show" covers the tournament.';
+    const html = buildRoundupHtml(arts, 1, summary);
+    expect(html).not.toContain('<a href="https://y.com/sports" style="color:#b45535;text-decoration:underline');
+  });
+
+  test('does not double-link a story cited via marker and also named by title', () => {
+    const arts = [article({ title: 'Apple Does Fusion', url: 'https://a.com/fusion' })];
+    const summary = 'Om Malik on {{fusion energy|1}} — Apple Does Fusion is worth your time.';
+    const html = buildRoundupHtml(arts, 1, summary);
+    // Count intro-styled links only (the article card below links the URL too).
+    const introLinks = html.match(/href="https:\/\/a\.com\/fusion" style="color:#b45535;text-decoration:underline/g) || [];
+    expect(introLinks.length).toBe(1);
+  });
+
+  test('strips greeting and sign-off filler paragraphs but keeps the news', () => {
+    const { stripFillerParagraphs } = require('./email');
+    const text = "Let's get started, shall we?\n\nPortugal's 2017 wildfires get the documentary treatment.\n\nSo, there you have it, folks. That's today's rundown. Until next time, keep exploring.";
+    const cleaned = stripFillerParagraphs(text);
+    expect(cleaned).toBe("Portugal's 2017 wildfires get the documentary treatment.");
+  });
+
+  test('never strips the only paragraph even if it pattern-matches filler', () => {
+    const { stripFillerParagraphs } = require('./email');
+    expect(stripFillerParagraphs("Welcome to the future: robots now file taxes.")).toBe("Welcome to the future: robots now file taxes.");
+  });
+
+  test("strips a \"Here's the opening note\" preamble paragraph", () => {
+    const { stripFillerParagraphs } = require('./email');
+    const text = "Here's the opening note for your daily reading rundown:\n\nWashington had a loud day.";
+    expect(stripFillerParagraphs(text)).toBe('Washington had a loud day.');
+  });
+
+  test('strips a generic preamble line before rendering the intro', () => {
+    const html = buildRoundupHtml([article()], 1, 'Here is a summary of your reading queue:\n\nThe real briefing starts here.');
+    expect(html).toContain('The real briefing starts here.');
+    expect(html).not.toContain('Here is a summary');
+  });
+
   test('strips citation markers that reference a missing story, keeping the words', () => {
     const html = buildRoundupHtml([article({ url: 'https://a.com/x' })], 1, 'A claim about {{something big|9}} today.');
     expect(html).toContain('something big');

--- a/src/email.test.ts
+++ b/src/email.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Tests for the email roundup module
 // ABOUTME: Covers HTML generation, escaping, provider resolution, curation, summary, and send logic
 
-import { escapeHtml, buildRoundupHtml, sendTestEmail, sendRoundup, resolveSmtpConfig, SMTP_PROVIDERS, curateArticles, generateRoundupSummary, buildRoundup, filterByLookback, formatSummaryCredit } from './email';
+import { escapeHtml, buildRoundupHtml, sendTestEmail, sendRoundup, resolveSmtpConfig, SMTP_PROVIDERS, curateArticles, generateRoundupSummary, buildRoundup, filterByLookback, formatSummaryCredit, scoreArticle, groupByCategory } from './email';
 import type { EmailConfig, ArticleMeta } from './email';
 
 jest.mock('./summarizer', () => ({
@@ -327,6 +327,99 @@ describe('curateArticles', () => {
     const result = curateArticles(articles, undefined, undefined, 6);
     const cats = new Set(result.map(a => a.categories?.[0]));
     expect(cats.size).toBeGreaterThan(1);
+  });
+});
+
+describe('scoreArticle', () => {
+  const now = Date.parse('2026-07-18T12:00:00Z');
+
+  test('rewards fresher stories', () => {
+    const fresh = scoreArticle(article({ bookmarked: '2026-07-18T11:00:00Z' }), { now });
+    const old = scoreArticle(article({ bookmarked: '2026-07-17T12:00:00Z' }), { now });
+    expect(fresh).toBeGreaterThan(old);
+  });
+
+  test('rewards richer content and watched entities', () => {
+    const plain = scoreArticle(article({ title: 'Plain' }), { now });
+    const rich = scoreArticle(article({ title: 'Plain', excerpt: 'x', image: 'https://i/x.jpg' }), { now });
+    expect(rich).toBeGreaterThan(plain);
+
+    const watched = scoreArticle(
+      article({ title: 'Apple ships a thing' }),
+      { now, mentionCounts: new Map(), watchedEntities: new Set(['Apple']) },
+    );
+    expect(watched).toBeGreaterThan(plain);
+  });
+
+  test('missing or unparseable bookmark contributes no recency', () => {
+    expect(scoreArticle(article({}), { now })).toBe(0);
+    expect(scoreArticle(article({ bookmarked: 'not-a-date' }), { now })).toBe(0);
+  });
+});
+
+describe('groupByCategory section ranking', () => {
+  const sectionOrder = (m: Map<string, unknown>) => [...m.keys()];
+
+  test('without a score, falls back to alphabetical with More last', () => {
+    const groups = groupByCategory([
+      article({ categories: ['Crypto'] }),
+      article({ categories: ['AI'] }),
+      article({}), // -> More
+    ]);
+    expect(sectionOrder(groups)).toEqual(['AI', 'Crypto', 'More']);
+  });
+
+  test('with a score, the strongest section leads (not alphabetical)', () => {
+    const arts = [
+      article({ title: 'weak ai', categories: ['AI'] }),
+      article({ title: 'huge crypto story', categories: ['Crypto'] }),
+    ];
+    const score = (a: ArticleMeta) => (a.categories?.[0] === 'Crypto' ? 10 : 1);
+    const groups = groupByCategory(arts, { score, seed: 'day' });
+    // Crypto outranks AI despite coming later in the alphabet.
+    expect(sectionOrder(groups)).toEqual(['Crypto', 'AI']);
+  });
+
+  test("the strongest story sorts first within a section (it becomes the hero)", () => {
+    const arts = [
+      article({ title: 'quiet', categories: ['AI'], filename: 'q.md' }),
+      article({ title: 'loud', categories: ['AI'], filename: 'l.md' }),
+    ];
+    const score = (a: ArticleMeta) => (a.title === 'loud' ? 9 : 1);
+    const groups = groupByCategory(arts, { score, seed: 'day' });
+    expect(groups.get('AI')![0].title).toBe('loud');
+  });
+
+  test('More stays last even when it scores highest', () => {
+    const arts = [
+      article({ title: 'strong uncat' }), // More
+      article({ title: 'ai', categories: ['AI'] }),
+    ];
+    const score = (a: ArticleMeta) => (a.categories?.[0] ? 1 : 100);
+    const groups = groupByCategory(arts, { score, seed: 'day' });
+    expect(sectionOrder(groups)[sectionOrder(groups).length - 1]).toBe('More');
+  });
+
+  test('ties reshuffle across days (seed) instead of freezing', () => {
+    // All sections score zero -> pure tie; different daily seeds should be able
+    // to lead with different sections.
+    const arts = [
+      article({ categories: ['AI'] }),
+      article({ categories: ['Business'] }),
+      article({ categories: ['Crypto'] }),
+      article({ categories: ['Design'] }),
+    ];
+    const score = () => 0;
+    const leads = new Set<string>();
+    for (const seed of ['2026-07-18', '2026-07-19', '2026-07-20', '2026-07-21', '2026-07-22']) {
+      leads.add(sectionOrder(groupByCategory(arts, { score, seed }))[0]);
+    }
+    // Not the same section every day.
+    expect(leads.size).toBeGreaterThan(1);
+    // But deterministic for a given seed.
+    const a = sectionOrder(groupByCategory(arts, { score, seed: 'fixed' }));
+    const b = sectionOrder(groupByCategory(arts, { score, seed: 'fixed' }));
+    expect(a).toEqual(b);
   });
 });
 

--- a/src/email.test.ts
+++ b/src/email.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Tests for the email roundup module
 // ABOUTME: Covers HTML generation, escaping, provider resolution, curation, summary, and send logic
 
-import { escapeHtml, buildRoundupHtml, sendTestEmail, sendRoundup, resolveSmtpConfig, SMTP_PROVIDERS, curateArticles, generateRoundupSummary, buildRoundup, filterByLookback, formatModelDisclosure } from './email';
+import { escapeHtml, buildRoundupHtml, sendTestEmail, sendRoundup, resolveSmtpConfig, SMTP_PROVIDERS, curateArticles, generateRoundupSummary, buildRoundup, filterByLookback, formatSummaryCredit } from './email';
 import type { EmailConfig, ArticleMeta } from './email';
 
 jest.mock('./summarizer', () => ({
@@ -244,15 +244,15 @@ describe('buildRoundupHtml', () => {
     expect(html).toContain('Third para, the payoff.');
   });
 
-  test('discloses the AI model that wrote the intro when provided', () => {
-    const html = buildRoundupHtml([article()], 1, 'A sharp little briefing.', 'Claude Haiku 4.5');
-    expect(html).toContain('This intro was written by');
-    expect(html).toContain('Claude Haiku 4.5');
+  test('credits the AI that wrote the intro when provided', () => {
+    const html = buildRoundupHtml([article()], 1, 'A sharp little briefing.', 'Claude');
+    expect(html).toContain('Summary by');
+    expect(html).toContain('Claude');
   });
 
-  test('omits the AI disclosure when no model is provided', () => {
+  test('omits the AI credit when none is provided', () => {
     const html = buildRoundupHtml([article()], 1, 'A sharp little briefing.');
-    expect(html).not.toContain('This intro was written by');
+    expect(html).not.toContain('Summary by');
   });
 });
 
@@ -463,14 +463,14 @@ describe('buildRoundup', () => {
     const result = await buildRoundup(cfg(), async () => articles);
 
     expect(result.summary).toBe('A fresh editorial note.');
-    expect(result.summaryModel).toBe('GPT-5');
+    expect(result.summaryCredit).toBe('GPT');
     expect(result.articles).toHaveLength(2);
     expect(result.html).toContain('Quantum chips ship');
     expect(result.html).toContain('New transit plan');
     expect(result.html).toContain('A fresh editorial note.');
-    // The AI-written intro discloses which model produced it.
-    expect(result.html).toContain('This intro was written by');
-    expect(result.html).toContain('GPT-5');
+    // The AI-written intro credits which AI produced it (brand only).
+    expect(result.html).toContain('Summary by');
+    expect(result.html).toContain('GPT');
     expect(result.subject).toContain('The Pull Read Rundown');
   });
 
@@ -479,40 +479,35 @@ describe('buildRoundup', () => {
     const result = await buildRoundup(cfg(), async () => articles);
 
     expect(result.summary).toBeNull();
-    expect(result.summaryModel).toBeNull();
+    expect(result.summaryCredit).toBeNull();
     expect(result.html).toContain('Solo story');
-    expect(result.html).not.toContain('This intro was written by');
+    expect(result.html).not.toContain('Summary by');
     expect(mockPromptLLM).not.toHaveBeenCalled();
   });
 });
 
-describe('formatModelDisclosure', () => {
-  test('formats Anthropic Claude model ids', () => {
-    expect(formatModelDisclosure('anthropic', 'claude-haiku-4-5-20251001')).toBe('Claude Haiku 4.5');
-    expect(formatModelDisclosure('anthropic', 'claude-opus-4-7')).toBe('Claude Opus 4.7');
+describe('formatSummaryCredit', () => {
+  test('credits a brand, not a specific model/version', () => {
+    expect(formatSummaryCredit('anthropic', 'claude-haiku-4-5-20251001')).toBe('Claude');
+    expect(formatSummaryCredit('anthropic', 'claude-opus-4-7')).toBe('Claude');
+    expect(formatSummaryCredit('openai', 'gpt-5')).toBe('GPT');
+    expect(formatSummaryCredit('openai', 'gpt-4.1-nano')).toBe('GPT');
+    expect(formatSummaryCredit('gemini', 'gemini-2.5-flash-lite')).toBe('Gemini');
   });
 
-  test('formats OpenAI model ids', () => {
-    expect(formatModelDisclosure('openai', 'gpt-5')).toBe('GPT-5');
-    expect(formatModelDisclosure('openai', 'gpt-5-mini')).toBe('GPT-5 mini');
-    expect(formatModelDisclosure('openai', 'gpt-4.1-nano')).toBe('GPT-4.1 nano');
+  test('names Apple Intelligence (no on-device model detail)', () => {
+    expect(formatSummaryCredit('apple', 'on-device')).toBe('Apple Intelligence');
+    expect(formatSummaryCredit('apple', 'apple-on-device')).toBe('Apple Intelligence');
   });
 
-  test('formats Gemini model ids', () => {
-    expect(formatModelDisclosure('gemini', 'gemini-2.5-flash-lite')).toBe('Gemini 2.5 Flash Lite');
-    expect(formatModelDisclosure('gemini', 'gemini-2.5-pro')).toBe('Gemini 2.5 Pro');
+  test('derives the brand from OpenRouter-routed model ids', () => {
+    expect(formatSummaryCredit('openrouter', 'anthropic/claude-haiku-4.5')).toBe('Claude');
+    expect(formatSummaryCredit('openrouter', 'google/gemini-2.5-flash')).toBe('Gemini');
+    expect(formatSummaryCredit('openrouter', 'meta-llama/llama-3.3-70b-instruct:free')).toBe('Llama');
   });
 
-  test('names Apple Intelligence as on-device', () => {
-    expect(formatModelDisclosure('apple', 'on-device')).toBe('Apple Intelligence (on-device)');
-    expect(formatModelDisclosure('apple', 'apple-on-device')).toBe('Apple Intelligence (on-device)');
-  });
-
-  test('keeps the OpenRouter routing visible', () => {
-    expect(formatModelDisclosure('openrouter', 'anthropic/claude-haiku-4.5')).toBe('Claude Haiku 4.5 (via OpenRouter)');
-  });
-
-  test('falls back to a clean title-case name for unknown models', () => {
-    expect(formatModelDisclosure('openrouter', 'meta-llama/llama-3.3-70b-instruct:free')).toBe('Llama 3.3 70b Instruct (via OpenRouter)');
+  test('falls back to the provider brand when the model id is unrecognized', () => {
+    expect(formatSummaryCredit('anthropic', '')).toBe('Claude');
+    expect(formatSummaryCredit('openai', 'some-unknown-id')).toBe('GPT');
   });
 });

--- a/src/email.ts
+++ b/src/email.ts
@@ -239,7 +239,7 @@ export function buildRoundupHtml(
   articles: ArticleMeta[],
   lookbackDays: number,
   summary?: string | null,
-  summaryModel?: string | null,
+  summaryCredit?: string | null,
 ): string {
   const today = new Date().toLocaleDateString('en-US', {
     weekday: 'long', month: 'long', day: 'numeric', year: 'numeric',
@@ -271,10 +271,10 @@ export function buildRoundupHtml(
 `;
 
   if (summary) {
-    const disclosure = summaryModel
+    const disclosure = summaryCredit
       ? `\n<div style="margin-top:20px;padding-top:15px;border-top:1px solid #efe4dc;font-size:12px;color:#a99f95;letter-spacing:0.01em">`
-        + `<span style="color:#b45535">&#10022;</span> This intro was written by `
-        + `<span style="color:#7d746b;font-weight:600">${escapeHtml(summaryModel)}</span></div>`
+        + `<span style="color:#b45535">&#10022;</span> Summary by `
+        + `<span style="color:#7d746b;font-weight:600">${escapeHtml(summaryCredit)}</span></div>`
       : '';
     html += `<div style="background:#faf8f6;border:1px solid #efe7df;border-left:3px solid #b45535;border-radius:10px;padding:26px 28px;margin-bottom:34px">
 ${renderSummaryParagraphs(summary)}${disclosure}
@@ -311,72 +311,36 @@ export function escapeHtml(s: string): string {
 }
 
 /**
- * Turn a raw model id into a reader-friendly name for the AI-disclosure byline
- * (e.g. `claude-haiku-4-5-20251001` → "Claude Haiku 4.5", `gpt-5-mini` → "GPT-5
- * mini"). Falls back to a title-cased cleanup for models we don't special-case.
+ * Brand-level credit for the AI that wrote the intro — e.g. "Claude", "Apple
+ * Intelligence", "Gemini". We deliberately don't expose the exact model/version;
+ * the family name is enough disclosure and reads cleaner in the byline.
  */
-function prettyModelName(model: string): string {
-  const raw = (model || '').trim();
-  if (!raw) return 'an AI model';
-  const lower = raw.toLowerCase();
-
-  // Claude: claude-haiku-4-5-20251001 / claude-opus-4.7 → Claude Haiku 4.5 / Claude Opus 4.7
-  let m = lower.match(/^claude-(haiku|sonnet|opus)-(\d+)[-.](\d+)/);
-  if (m) {
-    const tier = m[1].charAt(0).toUpperCase() + m[1].slice(1);
-    return `Claude ${tier} ${m[2]}.${m[3]}`;
-  }
-  if (lower.startsWith('claude')) return 'Claude';
-
-  // OpenAI GPT: gpt-5 / gpt-5-mini / gpt-4.1-nano → GPT-5 / GPT-5 mini / GPT-4.1 nano
-  m = lower.match(/^gpt-(\d+(?:\.\d+)?)(?:-(nano|mini|turbo))?/);
-  if (m) {
-    return `GPT-${m[1]}${m[2] ? ` ${m[2]}` : ''}`;
-  }
-  // OpenAI o-series: o3-mini → o3-mini
-  m = lower.match(/^o(\d+)(?:-(nano|mini))?/);
-  if (m) {
-    return `o${m[1]}${m[2] ? `-${m[2]}` : ''}`;
-  }
-
-  // Gemini: gemini-2.5-flash-lite → Gemini 2.5 Flash Lite
-  m = lower.match(/^gemini-(\d+(?:\.\d+)?)-(flash-lite|flash|pro)/);
-  if (m) {
-    const tierMap: Record<string, string> = { 'flash-lite': 'Flash Lite', 'flash': 'Flash', 'pro': 'Pro' };
-    return `Gemini ${m[1]} ${tierMap[m[2]]}`;
-  }
-  if (lower.startsWith('gemini')) return 'Gemini';
-
-  // Fallback: strip an OpenRouter ":free" tag, split on separators, title-case words.
-  return raw
-    .replace(/:free$/i, '')
-    .replace(/[-_/]+/g, ' ')
-    .split(/\s+/)
-    .filter(Boolean)
-    .map(w => (/^\d/.test(w) ? w : w.charAt(0).toUpperCase() + w.slice(1)))
-    .join(' ')
-    .trim() || 'an AI model';
-}
-
-/**
- * Human-readable disclosure of which model wrote the editorial intro. Keeps the
- * hosting provider visible when it isn't obvious from the model name (Apple's
- * on-device model, OpenRouter-routed models).
- */
-export function formatModelDisclosure(provider: string, model: string): string {
-  const raw = (model || '').trim();
-  const lower = raw.toLowerCase();
+export function formatSummaryCredit(provider: string, model: string): string {
+  const lower = (model || '').toLowerCase();
 
   if (provider === 'apple' || lower === 'on-device' || lower.includes('apple')) {
-    return 'Apple Intelligence (on-device)';
+    return 'Apple Intelligence';
   }
 
-  if (provider === 'openrouter') {
-    const base = raw.includes('/') ? raw.split('/').pop() || raw : raw;
-    return `${prettyModelName(base)} (via OpenRouter)`;
-  }
+  // Recognize the model family from its id — the reliable signal for
+  // OpenRouter-routed models, which name the underlying vendor in the id.
+  const family =
+    lower.includes('claude') ? 'Claude'
+    : lower.includes('gemini') ? 'Gemini'
+    : lower.includes('gpt') || /(^|[^a-z])o\d/.test(lower) ? 'GPT'
+    : lower.includes('llama') ? 'Llama'
+    : lower.includes('deepseek') ? 'DeepSeek'
+    : lower.includes('mistral') || lower.includes('mixtral') ? 'Mistral'
+    : null;
 
-  return prettyModelName(raw);
+  if (family) return family;
+
+  switch (provider) {
+    case 'anthropic': return 'Claude';
+    case 'openai': return 'GPT';
+    case 'gemini': return 'Gemini';
+    default: return 'AI';
+  }
 }
 
 async function validateArticleImages(articles: ArticleMeta[]): Promise<void> {
@@ -511,8 +475,8 @@ export interface RoundupResult {
   html: string;
   subject: string;
   summary: string | null;
-  /** Reader-friendly name of the model that wrote the intro, if any. */
-  summaryModel: string | null;
+  /** Brand-level credit for the AI that wrote the intro (e.g. "Claude"), if any. */
+  summaryCredit: string | null;
   articles: ArticleMeta[];
 }
 
@@ -575,15 +539,15 @@ export async function buildRoundup(
   // Generate AI editorial summary (non-blocking — roundup renders even if this fails)
   const summaryResult = await generateRoundupSummary(curated);
   const summary = summaryResult?.text ?? null;
-  const summaryModel = summaryResult
-    ? formatModelDisclosure(summaryResult.provider, summaryResult.model)
+  const summaryCredit = summaryResult
+    ? formatSummaryCredit(summaryResult.provider, summaryResult.model)
     : null;
 
-  const html = buildRoundupHtml(curated, cfg.lookbackDays, summary, summaryModel);
+  const html = buildRoundupHtml(curated, cfg.lookbackDays, summary, summaryCredit);
   const today = new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric' });
   const subject = `The Pull Read Rundown — ${today}`;
 
-  return { html, subject, summary, summaryModel, articles: curated };
+  return { html, subject, summary, summaryCredit, articles: curated };
 }
 
 export async function sendRoundup(

--- a/src/email.ts
+++ b/src/email.ts
@@ -111,6 +111,7 @@ export interface ArticleMeta {
   feed?: string;
   bookmarked?: string;
   excerpt?: string;
+  summary?: string;
   image?: string;
   categories?: string[];
 }
@@ -246,32 +247,217 @@ function categorySection(name: string, articles: ArticleMeta[]): string {
   return html;
 }
 
+const SUMMARY_LINK_STYLE = 'color:#b45535;text-decoration:underline;text-underline-offset:2px';
+
+/** Case/quote/whitespace-insensitive form for comparing a mention to a title. */
+function normalizeForTitleMatch(s: string): string {
+  return s.toLowerCase().replace(/[’‘]/g, "'").replace(/[“”]/g, '"')
+    .replace(/\s+/g, ' ').trim().replace(/[.,;:!?]+$/, '');
+}
+
+/** The distinctive part of a title — before any " | Show Name" / " (Full Episode)" suffix. */
+function titleCore(title: string): string {
+  return title.split(' | ')[0].split(' (')[0].trim();
+}
+
+/**
+ * Does a quoted span from the model's prose name this title? Exact match, the
+ * title's core, or a shortened form covering at least half the title all count;
+ * short generic fragments (a show name shared by many titles) do not.
+ */
+function quotedSpanNamesTitle(spanNorm: string, escapedTitle: string, escapedCore: string): boolean {
+  const t = normalizeForTitleMatch(escapedTitle);
+  if (!spanNorm || !t) return false;
+  if (spanNorm === t || spanNorm.includes(t)) return true;
+  if (spanNorm === normalizeForTitleMatch(escapedCore)) return true;
+  return t.includes(spanNorm) && spanNorm.length >= t.length / 2;
+}
+
+/** Normalize one whitespace-delimited token from escaped HTML for word matching. */
+function normalizeToken(raw: string): string {
+  return raw.toLowerCase()
+    .replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&amp;/g, '&')
+    .replace(/[’‘]/g, "'").replace(/[“”]/g, '"')
+    .replace(/^[^a-z0-9&]+/, '').replace(/[^a-z0-9&]+$/, '');
+}
+
+/**
+ * Find a run of words in `segment` (escaped HTML, no anchors) matching the
+ * beginning of the title core — how prose naturally shortens a long title
+ * ("Nordstrom Anniversary Sale 2026" for "Nordstrom Anniversary Sale 2026 –
+ * Picks for Men | Dapper"). Returns the [start, end) span to link, or null.
+ * Requires at least 3 matched words and 14 matched characters (or the whole
+ * core) so common short phrases never false-match.
+ */
+function findTitleCoreRun(segment: string, core: string): { start: number; end: number } | null {
+  const coreWords = core.split(/\s+/).map(normalizeToken).filter(Boolean);
+  if (coreWords.length === 0) return null;
+
+  const tokens: Array<{ norm: string; start: number; end: number }> = [];
+  const tokenRe = /\S+/g;
+  let m: RegExpExecArray | null;
+  while ((m = tokenRe.exec(segment)) !== null) {
+    tokens.push({ norm: normalizeToken(m[0]), start: m.index, end: m.index + m[0].length });
+  }
+
+  const stopwords = new Set(['the', 'a', 'an', 'of', 'to', 'in', 'on', 'at', 'and', '&', 'or', 'for', 'with', 'by', 'is', 'are', 'was', 'vs', '-', '–', '—']);
+  for (let i = 0; i < tokens.length; i++) {
+    if (!tokens[i].norm || tokens[i].norm !== coreWords[0]) continue;
+    let len = 1;
+    while (len < coreWords.length && i + len < tokens.length && tokens[i + len].norm === coreWords[len]) len++;
+    // A partial match must not end on a stopword — "Jake Johnson, the beloved
+    // actor" matching title "Jake Johnson - The Dink" through "the" reads broken.
+    while (len > 0 && len < coreWords.length && stopwords.has(coreWords[len - 1])) len--;
+    if (len === 0) continue;
+    const last = tokens[i + len - 1];
+    const matchedChars = last.end - tokens[i].start;
+    if (len === coreWords.length || (len >= 3 && matchedChars >= 14)) {
+      // Trim trailing punctuation off the final token so it stays outside the link.
+      const rawRun = segment.slice(tokens[i].start, last.end);
+      const trimmed = rawRun.replace(/(?:&(?:quot|amp|#39);|[^A-Za-z0-9)])+$/, '');
+      return { start: tokens[i].start, end: tokens[i].start + (trimmed.length || rawRun.length) };
+    }
+  }
+  return null;
+}
+
+/**
+ * Wrap the first plain-text occurrence of `escapedTitle` (already HTML-escaped,
+ * matched case-insensitively outside existing <a> tags) in a link. Returns the
+ * updated HTML, or null if the title isn't mentioned.
+ */
+function linkTitleOutsideAnchors(html: string, escapedTitle: string, url: string): string | null {
+  const segments = html.split(/(<a\b[^>]*>[\s\S]*?<\/a>)/);
+  for (let i = 0; i < segments.length; i++) {
+    if (segments[i].startsWith('<a')) continue;
+    const idx = segments[i].toLowerCase().indexOf(escapedTitle.toLowerCase());
+    if (idx === -1) continue;
+    const matched = segments[i].slice(idx, idx + escapedTitle.length);
+    segments[i] = segments[i].slice(0, idx)
+      + `<a href="${escapeHtml(url)}" style="${SUMMARY_LINK_STYLE}">${matched}</a>`
+      + segments[i].slice(idx + escapedTitle.length);
+    return segments.join('');
+  }
+  return null;
+}
+
 /**
  * Render the AI editorial note. Splits into paragraphs (blank-line breaks, then
  * single newlines) so it reads like a reporter's briefing, and turns the model's
  * inline story references — written as `{{linked words|N}}` — into links to the
- * matching article (by 1-based index into `citationUrls`). Markers that point at
+ * matching article (by 1-based index into `citations`). Markers that point at
  * a missing story, or any stray/unbalanced braces, are stripped so nothing leaks.
+ * Stories the model mentions by exact title without a marker (Apple Intelligence
+ * ignores the marker convention) are linked too, same as the in-app briefing.
  */
-function renderSummaryParagraphs(summary: string, citationUrls: string[] = []): string {
+function renderSummaryParagraphs(summary: string, citations: Array<{ title: string; url: string }> = []): string {
+  // Parity with the in-app briefing: drop the generic preamble line some models prepend.
+  const cleaned = summary.replace(/^(?:here(?:'s|\s+is)|below\s+is|this\s+is)\s+(?:a|the|your)?\s*(?:summary|overview|briefing|rundown|opening\s+note|editorial\s+note)[^\n]*\n+/i, '');
+
+  const linkedUrls = new Set<string>();
+
+  // Models sometimes number markers wrong (e.g. renumbering their mentions
+  // 1, 2, 3… regardless of the list). When the linked phrase itself names a
+  // story — it matches a title, or a title matches it — trust the words over
+  // the number. `phrase` arrives already HTML-escaped, so compare escaped.
+  const citationByPhrase = (escapedPhrase: string): { title: string; url: string } | undefined => {
+    const p = escapedPhrase.trim().toLowerCase();
+    if (p.length < 8) return undefined;
+    return citations.find(c => {
+      if (!c.title || !c.url) return false;
+      const t = escapeHtml(c.title).trim().toLowerCase();
+      return t === p || p.includes(t) || (t.includes(p) && p.length >= t.length / 2);
+    });
+  };
+
   const linkify = (escaped: string): string =>
     escaped
       .replace(/\{\{([^{}|]+)\|(\d+)\}\}/g, (_m, phrase: string, n: string) => {
-        const url = citationUrls[parseInt(n, 10) - 1];
-        if (!url) return phrase; // out of range — keep the words, drop the marker
-        return `<a href="${escapeHtml(url)}" style="color:#b45535;text-decoration:underline;text-underline-offset:2px">${phrase}</a>`;
+        const cite = citationByPhrase(phrase) || citations[parseInt(n, 10) - 1];
+        if (!cite?.url) return phrase; // out of range — keep the words, drop the marker
+        linkedUrls.add(cite.url);
+        return `<a href="${escapeHtml(cite.url)}" style="${SUMMARY_LINK_STYLE}">${phrase}</a>`;
       })
       .replace(/\{\{|\}\}/g, ''); // drop any leftover markers
 
-  const byBlank = summary.split(/\n\s*\n/).map(s => s.trim()).filter(Boolean);
+  const byBlank = cleaned.split(/\n\s*\n/).map(s => s.trim()).filter(Boolean);
   const paras = byBlank.length > 1
     ? byBlank
-    : summary.split(/\n+/).map(s => s.trim()).filter(Boolean);
-  const finalParas = paras.length ? paras : [summary.trim()];
-  return finalParas
+    : cleaned.split(/\n+/).map(s => s.trim()).filter(Boolean);
+  const finalParas = paras.length ? paras : [cleaned.trim()];
+  const htmlParas = finalParas.map(p => linkify(escapeHtml(p)));
+
+  // Fallback linking for models that skip the {{…|N}} convention but still name
+  // stories by title: link the first mention of each not-yet-linked title.
+  for (const cite of citations) {
+    if (!cite.url || !cite.title || linkedUrls.has(cite.url)) continue;
+    const escapedTitle = escapeHtml(cite.title);
+    for (let i = 0; i < htmlParas.length; i++) {
+      const replaced = linkTitleOutsideAnchors(htmlParas[i], escapedTitle, cite.url);
+      if (replaced) {
+        htmlParas[i] = replaced;
+        linkedUrls.add(cite.url);
+        break;
+      }
+    }
+  }
+
+  // Second fallback: models often QUOTE a shortened form of a title ("Story
+  // Name" without the | Show Name suffix). Link quoted spans that clearly
+  // name a story, matched fuzzily.
+  const quoteRe = /(&quot;|“)(.{8,180}?)(&quot;|”)/g;
+  for (const cite of citations) {
+    if (!cite.url || !cite.title || linkedUrls.has(cite.url)) continue;
+    const escapedTitle = escapeHtml(cite.title);
+    const escapedCore = escapeHtml(titleCore(cite.title));
+    let done = false;
+    for (let i = 0; i < htmlParas.length && !done; i++) {
+      const segments = htmlParas[i].split(/(<a\b[^>]*>[\s\S]*?<\/a>)/);
+      for (let s = 0; s < segments.length && !done; s++) {
+        if (segments[s].startsWith('<a')) continue;
+        quoteRe.lastIndex = 0;
+        let m: RegExpExecArray | null;
+        while ((m = quoteRe.exec(segments[s])) !== null) {
+          if (!quotedSpanNamesTitle(normalizeForTitleMatch(m[2]), escapedTitle, escapedCore)) continue;
+          const start = m.index + m[1].length;
+          segments[s] = segments[s].slice(0, start)
+            + `<a href="${escapeHtml(cite.url)}" style="${SUMMARY_LINK_STYLE}">${m[2]}</a>`
+            + segments[s].slice(start + m[2].length);
+          htmlParas[i] = segments.join('');
+          linkedUrls.add(cite.url);
+          done = true;
+          break;
+        }
+      }
+    }
+  }
+
+  // Last fallback: unquoted shortened mentions — a word run matching the start
+  // of a story's title ("the Nordstrom Anniversary Sale 2026 promises…").
+  for (const cite of citations) {
+    if (!cite.url || !cite.title || linkedUrls.has(cite.url)) continue;
+    const escapedCore = escapeHtml(titleCore(cite.title));
+    let done = false;
+    for (let i = 0; i < htmlParas.length && !done; i++) {
+      const segments = htmlParas[i].split(/(<a\b[^>]*>[\s\S]*?<\/a>)/);
+      for (let s = 0; s < segments.length && !done; s++) {
+        if (segments[s].startsWith('<a')) continue;
+        const run = findTitleCoreRun(segments[s], escapedCore);
+        if (!run) continue;
+        segments[s] = segments[s].slice(0, run.start)
+          + `<a href="${escapeHtml(cite.url)}" style="${SUMMARY_LINK_STYLE}">${segments[s].slice(run.start, run.end)}</a>`
+          + segments[s].slice(run.end);
+        htmlParas[i] = segments.join('');
+        linkedUrls.add(cite.url);
+        done = true;
+      }
+    }
+  }
+
+  return htmlParas
     .map((p, i) => {
-      const mb = i === finalParas.length - 1 ? '0' : '15px';
-      return `<p style="margin:0 0 ${mb};font-size:16px;line-height:1.72;color:#33302d">${linkify(escapeHtml(p))}</p>`;
+      const mb = i === htmlParas.length - 1 ? '0' : '15px';
+      return `<p style="margin:0 0 ${mb};font-size:16px;line-height:1.72;color:#33302d">${p}</p>`;
     })
     .join('\n');
 }
@@ -316,14 +502,14 @@ export function buildRoundupHtml(
   if (summary) {
     // The note reads as a newsletter lede straight on the card — no bounding box.
     // Story references written as {{words|N}} link to the Nth article below.
-    const citationUrls = articles.map(a => a.url);
+    const citations = articles.map(a => ({ title: a.title, url: a.url }));
     const credit = summaryCredit
       ? `\n<div style="margin-top:16px;font-size:12px;color:#a99f95;letter-spacing:0.01em">`
         + `<span style="color:#b45535">&#10022;</span> Summary by `
         + `<span style="color:#7d746b;font-weight:600">${escapeHtml(summaryCredit)}</span></div>`
       : '';
     html += `<div style="margin:0 0 6px">
-${renderSummaryParagraphs(summary, citationUrls)}${credit}
+${renderSummaryParagraphs(summary, citations)}${credit}
 </div>`;
   }
 
@@ -493,27 +679,61 @@ export function curateArticles(
   return picked;
 }
 
-const ROUNDUP_SUMMARY_PROMPT = `You're writing the opening note for a daily reading rundown — the short briefing that sits at the very top of the newsletter. Write like a sharp, well-read reporter giving a curious friend the lay of the land: warm, direct, and genuinely interested, never breathless or salesy.
+/**
+ * Build the editorial-intro prompt. `strictTitles` swaps the {{phrase|N}} marker
+ * convention for a "copy the exact title" rule — small on-device models (Apple
+ * Intelligence) ignore the marker syntax, but do repeat titles verbatim, which
+ * the renderer's title-matching fallback then turns into links (the same
+ * approach the in-app briefing uses).
+ */
+function roundupSummaryPrompt(strictTitles: boolean): string {
+  const linking = strictTitles
+    ? `Linking (important):
+- LINKING RULE — THIS IS CRITICAL: every story you reference MUST be named by its exact title, copied word-for-word from the list below, wrapped in double quotes. Do not shorten, reword, or retitle it.
+- Reference 2 to 4 stories this way across the whole note, woven into the prose.`
+    : `Linking (important):
+- The stories below are numbered. When you reference a specific one, link the exact words that name it by wrapping them like {{these words|N}}, where N is that story's number from the list — write {{a short phrase naming story three|3}} to link story 3.
+- Link 2 to 4 stories across the whole note. Keep each linked phrase short (a noun phrase, not a full sentence), never link the same story twice, and double-check each N matches the story you're naming.
+- If you mention a story without a {{…|N}} marker, name it by its exact title as listed so it can be linked automatically.`;
+
+  return `You're writing the opening note for a daily reading rundown — the short briefing that sits at the very top of the newsletter. Write like a sharp, well-read reporter giving a curious friend the lay of the land: warm, direct, and genuinely interested, never breathless or salesy.
 
 Structure:
-- Write 2 to 3 SHORT paragraphs. Separate every paragraph with a blank line.
+- Write 2 to 3 SHORT paragraphs of flowing prose. Separate every paragraph with a blank line.
 - Keep each paragraph to 1-2 sentences. Tight beats long.
 - Open with the day's throughline — the theme or tension tying the stories together — not a roll call.
+- NEVER output bullet points, numbered lists, or a "quick updates" section. Every story you mention gets woven into a sentence.
 
 Voice:
 - Synthesize; don't enumerate. Never march down the list tacking "and it's a reminder that…" onto each item. That pattern is the single worst thing you can do here.
-- Be specific. Name the real stakes. "The AI debate is heating up" is flat — say what actually shifted and why it lands.
+- Be specific: name who did what and the real stakes. No vague trend-talk about debates heating up or landscapes shifting.
+- Cover the day's actual range — don't fixate on a single theme. If a strong story sits outside the throughline, give it one good sentence.
+- Write only about the stories listed below. Do not invent stories, and do not reuse any wording from these instructions.
 - Opinions welcome, clichés not.
 - Don't name every article or count how many there are.
 
-Linking (important):
-- The stories below are numbered. When you reference a specific one, link the exact words that name it by wrapping them like {{these words|N}}, where N is that story's number — e.g. {{Brussels forcing Google to share search data|3}}.
-- Link 2 to 4 stories across the whole note. Keep each linked phrase short (a noun phrase, not a full sentence), never link the same story twice, and never use a number that isn't in the list.
+${linking}
 
-Never use: "dive in", "buckle up", "without further ado", "let's get started", "here's what caught my eye", "in today's rundown", "welcome to".
+Never use: "dive in", "buckle up", "without further ado", "let's get started", "here's what caught my eye", "in today's rundown", "welcome to". No greetings, no sign-offs, no "that's the rundown" — start with the news and end with the news.
 
 Today's stories (numbered for linking):
 `;
+}
+
+/**
+ * Drop the throat-clearing and sign-off paragraphs small models tack on despite
+ * instructions ("Let's get started, shall we?", "So, there you have it, folks…").
+ * Only whole paragraphs that are clearly filler are removed; the news survives.
+ */
+export function stripFillerParagraphs(text: string): string {
+  const paras = text.split(/\n\s*\n/).map(p => p.trim()).filter(Boolean);
+  const greeting = /^(let'?s (get started|dive|begin)|welcome( to| back)?\b|good (morning|afternoon|evening)|hello|hi there|hey (there|folks|everyone)|alright,? (folks|everyone)|shall we|today,? we'?re diving|here(?:'s| is) (a |the |your )?(opening note|note|briefing|summary|rundown))/i;
+  const signoff = /(that'?s (today'?s|the|your) (rundown|briefing|roundup)|that'?s all for (today|now|this week)|until next time|don'?t forget to (share|subscribe|comment)|there you have it|happy reading|stay (tuned|curious)|keep (exploring|reading|questioning)|see you (tomorrow|next))/i;
+
+  while (paras.length > 1 && greeting.test(paras[0]) && paras[0].length < 160) paras.shift();
+  while (paras.length > 1 && signoff.test(paras[paras.length - 1])) paras.pop();
+  return paras.join('\n\n');
+}
 
 /** The editorial intro plus the model that wrote it, for AI disclosure. */
 export interface RoundupSummary {
@@ -529,27 +749,56 @@ export async function generateRoundupSummary(articles: ArticleMeta[]): Promise<R
 
   // Number the stories so the model can cite them inline as {{words|N}};
   // renderSummaryParagraphs maps N back to this same (curated) article order.
-  const articleList = articles
-    .slice(0, 15)
+  // Feed each story's summary (or excerpt) like the in-app briefing does —
+  // titles alone push small models toward vague filler prose.
+  const buildList = (maxArticles: number, gistCap: number) => articles
+    .slice(0, maxArticles)
     .map((a, i) => {
-      const excerpt = a.excerpt ? ` — ${a.excerpt.slice(0, 100)}` : '';
-      return `${i + 1}. ${a.title} (${a.domain || a.feed || ''})${excerpt}`;
+      const gist = a.summary || a.excerpt || '';
+      const detail = gist && gistCap > 0 ? `\n   ${a.summary ? 'Summary' : 'Excerpt'}: ${gist.slice(0, gistCap)}` : '';
+      return `${i + 1}. "${a.title}" (${a.domain || a.feed || ''})${detail}`;
     })
     .join('\n');
+
+  const base = roundupSummaryPrompt(config.provider === 'apple');
+  let articleList = buildList(15, 300);
+
+  if (config.provider === 'apple') {
+    // Apple Intelligence has a hard 4096-token window shared with the ~400-token
+    // reply, and roughly 3 chars/token on mixed text — a rich prompt overflows it
+    // and the whole intro is lost. Shrink the story gists (then the list) until
+    // the prompt fits comfortably.
+    const budget = 7000; // total prompt chars
+    for (const [n, cap] of [[15, 120], [12, 80], [10, 40], [8, 0], [5, 0]] as const) {
+      articleList = buildList(n, cap);
+      if (base.length + articleList.length <= budget) break;
+    }
+  }
 
   // Use promptLLM (not summarizeText): the roundup prompt IS the instruction.
   // summarizeText would prepend its own "Summarize this article…" wrapper, so the
   // model would summarize our instructions instead of following them — producing a
-  // near-static blurb anchored on the example lines in ROUNDUP_SUMMARY_PROMPT.
+  // near-static blurb anchored on the example lines in the prompt.
   // A slightly higher token budget lets the model write 2-3 short paragraphs.
-  const prompt = ROUNDUP_SUMMARY_PROMPT + articleList;
+  const run = async (list: string) => {
+    const result = await promptLLM(base + list, config, 400);
+    const text = stripFillerParagraphs(result.text.trim());
+    return text ? { text, model: result.model, provider: config.provider } : null;
+  };
   try {
-    const result = await promptLLM(prompt, config, 400);
-    const text = result.text.trim();
-    if (!text) return null;
-    return { text, model: result.model, provider: config.provider };
+    return await run(articleList);
   } catch (err) {
-    console.warn('[email] Failed to generate roundup summary:', err instanceof Error ? err.message : err);
+    const msg = err instanceof Error ? err.message : String(err);
+    // Last resort: a bare titles-only list still beats an email with no intro.
+    if (/context window/i.test(msg)) {
+      try {
+        return await run(buildList(5, 0));
+      } catch (retryErr) {
+        console.warn('[email] Roundup summary retry failed:', retryErr instanceof Error ? retryErr.message : retryErr);
+        return null;
+      }
+    }
+    console.warn('[email] Failed to generate roundup summary:', msg);
     return null;
   }
 }
@@ -588,7 +837,9 @@ export async function buildRoundup(
     articles = await fetchArticles();
   } else {
     try {
-      const resp = await fetch(`http://127.0.0.1:${port}/api/files`);
+      // summaries=1 includes each article's stored AI summary — the editorial
+      // intro prompt needs real content, not just titles, to stay specific.
+      const resp = await fetch(`http://127.0.0.1:${port}/api/files?summaries=1`);
       const allArticles = (await resp.json()) as ArticleMeta[];
       articles = filterByLookback(allArticles, cfg.lookbackDays);
     } catch (err) {

--- a/src/email.ts
+++ b/src/email.ts
@@ -139,19 +139,21 @@ function groupByCategory(articles: ArticleMeta[]): Map<string, ArticleMeta[]> {
 }
 
 /**
- * Deep link that opens an article inside Pull Read's reader — the email
- * equivalent of the in-app rundown, where tapping a headline opens the piece in
- * the reader rather than the raw publisher page. Headlines link here so the
- * email behaves like the app; a secondary link still offers the original source.
+ * Deep link that opens an article inside Pull Read's reader on desktop. It's
+ * offered as a secondary, desktop-only action (hidden on mobile via the media
+ * query in the document head, since there's no Pull Read mobile app yet) —
+ * headlines themselves link straight to the source so every recipient can read.
  */
 function pullReadLink(article: ArticleMeta): string {
   return `https://pullread.com/link?url=${encodeURIComponent(article.url)}&title=${encodeURIComponent(article.title)}`;
 }
 
-function articleLinks(article: ArticleMeta): string {
-  return `<a href="${escapeHtml(pullReadLink(article))}" style="color:#b45535;text-decoration:none;font-size:12px;font-weight:600">Open in Pull Read &rarr;</a>`
-    + `<span style="color:#d8d0c8;margin:0 8px">&middot;</span>`
-    + `<a href="${escapeHtml(article.url)}" style="color:#9a938c;text-decoration:none;font-size:12px">Read the original &#8599;</a>`;
+// "Open in Pull Read" — desktop only. The .pr-desktop-only class is hidden on
+// small screens by the media query in buildRoundupHtml's <head>.
+function openInPullRead(article: ArticleMeta): string {
+  return `<div class="pr-desktop-only" style="margin-top:9px">`
+    + `<a href="${escapeHtml(pullReadLink(article))}" style="color:#b45535;text-decoration:none;font-size:12px;font-weight:600">Open in Pull Read &rarr;</a>`
+    + `</div>`;
 }
 
 function metaLine(article: ArticleMeta): string {
@@ -163,7 +165,7 @@ function metaLine(article: ArticleMeta): string {
 function heroArticleHtml(article: ArticleMeta): string {
   const excerpt = truncateExcerpt(article.excerpt || '');
   const hasImage = article.image && article.image.startsWith('http');
-  const link = escapeHtml(pullReadLink(article));
+  const link = escapeHtml(article.url);
 
   if (hasImage) {
     // Image + text side by side using table layout (email-safe)
@@ -175,7 +177,7 @@ function heroArticleHtml(article: ArticleMeta): string {
 <a href="${link}" style="font-size:17px;color:#1a1a1a;text-decoration:none;font-weight:600;line-height:1.35">${escapeHtml(article.title)}</a>
 ${excerpt ? `<div style="font-size:13.5px;color:#6b6560;margin-top:6px;line-height:1.55">${escapeHtml(excerpt)}</div>` : ''}
 ${metaLine(article)}
-<div style="margin-top:9px">${articleLinks(article)}</div>
+${openInPullRead(article)}
 </td>
 </tr></table>`;
   }
@@ -185,18 +187,18 @@ ${metaLine(article)}
 <a href="${link}" style="font-size:17px;color:#1a1a1a;text-decoration:none;font-weight:600;line-height:1.35">${escapeHtml(article.title)}</a>
 ${excerpt ? `<div style="font-size:13.5px;color:#6b6560;margin-top:6px;line-height:1.55">${escapeHtml(excerpt)}</div>` : ''}
 ${metaLine(article)}
-<div style="margin-top:9px">${articleLinks(article)}</div>
+${openInPullRead(article)}
 </div>`;
 }
 
 function compactArticleHtml(article: ArticleMeta): string {
   const excerpt = truncateExcerpt(article.excerpt || '');
-  const link = escapeHtml(pullReadLink(article));
+  const link = escapeHtml(article.url);
   return `<div style="padding:16px 0;border-top:1px solid #f0ebe6">
 <a href="${link}" style="font-size:15px;color:#1a1a1a;text-decoration:none;font-weight:600;line-height:1.4">${escapeHtml(article.title)}</a>
 ${excerpt ? `<div style="font-size:13px;color:#6b6560;margin-top:5px;line-height:1.5">${escapeHtml(excerpt)}</div>` : ''}
 ${metaLine(article)}
-<div style="margin-top:8px">${articleLinks(article)}</div>
+${openInPullRead(article)}
 </div>`;
 }
 
@@ -217,11 +219,22 @@ function categorySection(name: string, articles: ArticleMeta[]): string {
 }
 
 /**
- * Split the AI editorial note into paragraphs so it reads like a reporter's
- * briefing rather than one dense block. Honors blank-line paragraph breaks,
- * falling back to single newlines, then to the whole note as one paragraph.
+ * Render the AI editorial note. Splits into paragraphs (blank-line breaks, then
+ * single newlines) so it reads like a reporter's briefing, and turns the model's
+ * inline story references — written as `{{linked words|N}}` — into links to the
+ * matching article (by 1-based index into `citationUrls`). Markers that point at
+ * a missing story, or any stray/unbalanced braces, are stripped so nothing leaks.
  */
-function renderSummaryParagraphs(summary: string): string {
+function renderSummaryParagraphs(summary: string, citationUrls: string[] = []): string {
+  const linkify = (escaped: string): string =>
+    escaped
+      .replace(/\{\{([^{}|]+)\|(\d+)\}\}/g, (_m, phrase: string, n: string) => {
+        const url = citationUrls[parseInt(n, 10) - 1];
+        if (!url) return phrase; // out of range — keep the words, drop the marker
+        return `<a href="${escapeHtml(url)}" style="color:#b45535;text-decoration:underline;text-underline-offset:2px">${phrase}</a>`;
+      })
+      .replace(/\{\{|\}\}/g, ''); // drop any leftover markers
+
   const byBlank = summary.split(/\n\s*\n/).map(s => s.trim()).filter(Boolean);
   const paras = byBlank.length > 1
     ? byBlank
@@ -230,7 +243,7 @@ function renderSummaryParagraphs(summary: string): string {
   return finalParas
     .map((p, i) => {
       const mb = i === finalParas.length - 1 ? '0' : '15px';
-      return `<p style="margin:0 0 ${mb};font-size:16px;line-height:1.72;color:#33302d">${escapeHtml(p)}</p>`;
+      return `<p style="margin:0 0 ${mb};font-size:16px;line-height:1.72;color:#33302d">${linkify(escapeHtml(p))}</p>`;
     })
     .join('\n');
 }
@@ -253,7 +266,8 @@ export function buildRoundupHtml(
   let html = `<!DOCTYPE html>
 <html>
 <head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><meta name="color-scheme" content="light only"><meta name="supported-color-schemes" content="light only">
-<style>:root{color-scheme:light only}body,table,td,div,p,a,span{color-scheme:light only}</style>
+<style>:root{color-scheme:light only}body,table,td,div,p,a,span{color-scheme:light only}
+@media only screen and (max-width:600px){.pr-desktop-only{display:none !important}}</style>
 </head>
 <body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;background-color:#f7f5f3;color:#1a1a1a;-webkit-font-smoothing:antialiased">
 <div style="max-width:600px;margin:0 auto;padding:28px 20px 32px;background-color:#f7f5f3">
@@ -271,13 +285,16 @@ export function buildRoundupHtml(
 `;
 
   if (summary) {
-    const disclosure = summaryCredit
-      ? `\n<div style="margin-top:20px;padding-top:15px;border-top:1px solid #efe4dc;font-size:12px;color:#a99f95;letter-spacing:0.01em">`
+    // The note reads as a newsletter lede straight on the card — no bounding box.
+    // Story references written as {{words|N}} link to the Nth article below.
+    const citationUrls = articles.map(a => a.url);
+    const credit = summaryCredit
+      ? `\n<div style="margin-top:16px;font-size:12px;color:#a99f95;letter-spacing:0.01em">`
         + `<span style="color:#b45535">&#10022;</span> Summary by `
         + `<span style="color:#7d746b;font-weight:600">${escapeHtml(summaryCredit)}</span></div>`
       : '';
-    html += `<div style="background:#faf8f6;border:1px solid #efe7df;border-left:3px solid #b45535;border-radius:10px;padding:26px 28px;margin-bottom:34px">
-${renderSummaryParagraphs(summary)}${disclosure}
+    html += `<div style="margin:0 0 6px">
+${renderSummaryParagraphs(summary, citationUrls)}${credit}
 </div>`;
   }
 
@@ -429,9 +446,13 @@ Voice:
 - Opinions welcome, clichés not.
 - Don't name every article or count how many there are.
 
+Linking (important):
+- The stories below are numbered. When you reference a specific one, link the exact words that name it by wrapping them like {{these words|N}}, where N is that story's number — e.g. {{Brussels forcing Google to share search data|3}}.
+- Link 2 to 4 stories across the whole note. Keep each linked phrase short (a noun phrase, not a full sentence), never link the same story twice, and never use a number that isn't in the list.
+
 Never use: "dive in", "buckle up", "without further ado", "let's get started", "here's what caught my eye", "in today's rundown", "welcome to".
 
-Today's articles:
+Today's stories (numbered for linking):
 `;
 
 /** The editorial intro plus the model that wrote it, for AI disclosure. */
@@ -446,11 +467,13 @@ export async function generateRoundupSummary(articles: ArticleMeta[]): Promise<R
   const config = loadLLMConfig();
   if (!config) return null;
 
+  // Number the stories so the model can cite them inline as {{words|N}};
+  // renderSummaryParagraphs maps N back to this same (curated) article order.
   const articleList = articles
     .slice(0, 15)
-    .map(a => {
+    .map((a, i) => {
       const excerpt = a.excerpt ? ` — ${a.excerpt.slice(0, 100)}` : '';
-      return `- ${a.title} (${a.domain || a.feed || ''})${excerpt}`;
+      return `${i + 1}. ${a.title} (${a.domain || a.feed || ''})${excerpt}`;
     })
     .join('\n');
 

--- a/src/email.ts
+++ b/src/email.ts
@@ -138,46 +138,29 @@ function groupByCategory(articles: ArticleMeta[]): Map<string, ArticleMeta[]> {
   return sorted;
 }
 
-/**
- * Deep link that opens an article inside Pull Read's reader on desktop. It's
- * offered as a secondary, desktop-only action (hidden on mobile via the media
- * query in the document head, since there's no Pull Read mobile app yet) —
- * headlines themselves link straight to the source so every recipient can read.
- */
-function pullReadLink(article: ArticleMeta): string {
-  return `https://pullread.com/link?url=${encodeURIComponent(article.url)}&title=${encodeURIComponent(article.title)}`;
-}
-
-// "Open in Pull Read" — desktop only. The .pr-desktop-only class is hidden on
-// small screens by the media query in buildRoundupHtml's <head>.
-function openInPullRead(article: ArticleMeta): string {
-  return `<div class="pr-desktop-only" style="margin-top:9px">`
-    + `<a href="${escapeHtml(pullReadLink(article))}" style="color:#b45535;text-decoration:none;font-size:12px;font-weight:600">Open in Pull Read &rarr;</a>`
-    + `</div>`;
-}
-
 function metaLine(article: ArticleMeta): string {
   const source = escapeHtml(article.domain || article.feed || '');
   const author = article.author ? ` <span style="color:#c9c1b9">&middot;</span> ${escapeHtml(article.author)}` : '';
   return `<div style="font-size:12px;color:#9a938c;margin-top:5px">${source}${author}</div>`;
 }
 
+// The whole headline is the link, straight to the source — no per-item CTA. On
+// mobile the image stacks above the text (.hero-cell / .hero-img in the head).
 function heroArticleHtml(article: ArticleMeta): string {
   const excerpt = truncateExcerpt(article.excerpt || '');
   const hasImage = article.image && article.image.startsWith('http');
   const link = escapeHtml(article.url);
 
   if (hasImage) {
-    // Image + text side by side using table layout (email-safe)
+    // Image + text side by side on desktop; stacked (image on top) on mobile.
     return `<table cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-bottom:22px"><tr>
-<td width="140" valign="top" style="padding-right:18px;width:140px">
+<td class="hero-cell hero-img" width="140" valign="top" style="padding-right:18px;width:140px">
 <a href="${link}" style="text-decoration:none"><img src="${escapeHtml(article.image!)}" width="140" height="96" alt="" style="object-fit:cover;display:block;width:140px;height:96px;border:0;border-radius:8px;background:#f0ebe7" /></a>
 </td>
-<td valign="top">
+<td class="hero-cell" valign="top">
 <a href="${link}" style="font-size:17px;color:#1a1a1a;text-decoration:none;font-weight:600;line-height:1.35">${escapeHtml(article.title)}</a>
 ${excerpt ? `<div style="font-size:13.5px;color:#6b6560;margin-top:6px;line-height:1.55">${escapeHtml(excerpt)}</div>` : ''}
 ${metaLine(article)}
-${openInPullRead(article)}
 </td>
 </tr></table>`;
   }
@@ -187,7 +170,6 @@ ${openInPullRead(article)}
 <a href="${link}" style="font-size:17px;color:#1a1a1a;text-decoration:none;font-weight:600;line-height:1.35">${escapeHtml(article.title)}</a>
 ${excerpt ? `<div style="font-size:13.5px;color:#6b6560;margin-top:6px;line-height:1.55">${escapeHtml(excerpt)}</div>` : ''}
 ${metaLine(article)}
-${openInPullRead(article)}
 </div>`;
 }
 
@@ -198,7 +180,6 @@ function compactArticleHtml(article: ArticleMeta): string {
 <a href="${link}" style="font-size:15px;color:#1a1a1a;text-decoration:none;font-weight:600;line-height:1.4">${escapeHtml(article.title)}</a>
 ${excerpt ? `<div style="font-size:13px;color:#6b6560;margin-top:5px;line-height:1.5">${escapeHtml(excerpt)}</div>` : ''}
 ${metaLine(article)}
-${openInPullRead(article)}
 </div>`;
 }
 
@@ -267,7 +248,7 @@ export function buildRoundupHtml(
 <html>
 <head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><meta name="color-scheme" content="light only"><meta name="supported-color-schemes" content="light only">
 <style>:root{color-scheme:light only}body,table,td,div,p,a,span{color-scheme:light only}
-@media only screen and (max-width:600px){.pr-desktop-only{display:none !important}}</style>
+@media only screen and (max-width:600px){.hero-cell{display:block !important;width:100% !important;padding-right:0 !important}.hero-img{padding-bottom:14px !important}.hero-img img{width:100% !important;height:180px !important;max-width:100% !important}}</style>
 </head>
 <body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;background-color:#f7f5f3;color:#1a1a1a;-webkit-font-smoothing:antialiased">
 <div style="max-width:600px;margin:0 auto;padding:28px 20px 32px;background-color:#f7f5f3">

--- a/src/email.ts
+++ b/src/email.ts
@@ -138,61 +138,72 @@ function groupByCategory(articles: ArticleMeta[]): Map<string, ArticleMeta[]> {
   return sorted;
 }
 
+/**
+ * Deep link that opens an article inside Pull Read's reader — the email
+ * equivalent of the in-app rundown, where tapping a headline opens the piece in
+ * the reader rather than the raw publisher page. Headlines link here so the
+ * email behaves like the app; a secondary link still offers the original source.
+ */
+function pullReadLink(article: ArticleMeta): string {
+  return `https://pullread.com/link?url=${encodeURIComponent(article.url)}&title=${encodeURIComponent(article.title)}`;
+}
+
 function articleLinks(article: ArticleMeta): string {
-  const prLink = `https://pullread.com/link?url=${encodeURIComponent(article.url)}&title=${encodeURIComponent(article.title)}`;
-  return `<a href="${escapeHtml(prLink)}" style="color:#b45535;text-decoration:none;font-size:12px;font-weight:500">Open in Pull Read</a>`
-    + `<span style="color:#ccc;margin:0 6px">&middot;</span>`
-    + `<a href="${escapeHtml(article.url)}" style="color:#888;text-decoration:none;font-size:12px">Read &rarr;</a>`;
+  return `<a href="${escapeHtml(pullReadLink(article))}" style="color:#b45535;text-decoration:none;font-size:12px;font-weight:600">Open in Pull Read &rarr;</a>`
+    + `<span style="color:#d8d0c8;margin:0 8px">&middot;</span>`
+    + `<a href="${escapeHtml(article.url)}" style="color:#9a938c;text-decoration:none;font-size:12px">Read the original &#8599;</a>`;
 }
 
 function metaLine(article: ArticleMeta): string {
   const source = escapeHtml(article.domain || article.feed || '');
-  const author = article.author ? ` <span style="color:#999">&middot;</span> ${escapeHtml(article.author)}` : '';
-  return `<div style="font-size:12px;color:#999;margin-top:2px">${source}${author}</div>`;
+  const author = article.author ? ` <span style="color:#c9c1b9">&middot;</span> ${escapeHtml(article.author)}` : '';
+  return `<div style="font-size:12px;color:#9a938c;margin-top:5px">${source}${author}</div>`;
 }
 
 function heroArticleHtml(article: ArticleMeta): string {
   const excerpt = truncateExcerpt(article.excerpt || '');
   const hasImage = article.image && article.image.startsWith('http');
+  const link = escapeHtml(pullReadLink(article));
 
   if (hasImage) {
     // Image + text side by side using table layout (email-safe)
-    return `<table cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-bottom:16px"><tr>
-<td width="130" valign="top" style="padding-right:16px;background:#f0ebe7;width:130px;height:90px">
-<a href="${escapeHtml(article.url)}" style="text-decoration:none"><img src="${escapeHtml(article.image!)}" width="130" height="90" alt="" style="object-fit:cover;display:block;width:130px;height:90px;border:0" /></a>
+    return `<table cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-bottom:22px"><tr>
+<td width="140" valign="top" style="padding-right:18px;width:140px">
+<a href="${link}" style="text-decoration:none"><img src="${escapeHtml(article.image!)}" width="140" height="96" alt="" style="object-fit:cover;display:block;width:140px;height:96px;border:0;border-radius:8px;background:#f0ebe7" /></a>
 </td>
 <td valign="top">
-<a href="${escapeHtml(article.url)}" style="font-size:16px;color:#1a1a1a;text-decoration:none;font-weight:600;line-height:1.3">${escapeHtml(article.title)}</a>
-${excerpt ? `<div style="font-size:13px;color:#666;margin-top:4px;line-height:1.4">${escapeHtml(excerpt)}</div>` : ''}
+<a href="${link}" style="font-size:17px;color:#1a1a1a;text-decoration:none;font-weight:600;line-height:1.35">${escapeHtml(article.title)}</a>
+${excerpt ? `<div style="font-size:13.5px;color:#6b6560;margin-top:6px;line-height:1.55">${escapeHtml(excerpt)}</div>` : ''}
 ${metaLine(article)}
-<div style="margin-top:6px">${articleLinks(article)}</div>
+<div style="margin-top:9px">${articleLinks(article)}</div>
 </td>
 </tr></table>`;
   }
 
   // No image — full-width text hero
-  return `<div style="margin-bottom:16px">
-<a href="${escapeHtml(article.url)}" style="font-size:16px;color:#1a1a1a;text-decoration:none;font-weight:600;line-height:1.3">${escapeHtml(article.title)}</a>
-${excerpt ? `<div style="font-size:13px;color:#666;margin-top:4px;line-height:1.4">${escapeHtml(excerpt)}</div>` : ''}
+  return `<div style="margin-bottom:22px">
+<a href="${link}" style="font-size:17px;color:#1a1a1a;text-decoration:none;font-weight:600;line-height:1.35">${escapeHtml(article.title)}</a>
+${excerpt ? `<div style="font-size:13.5px;color:#6b6560;margin-top:6px;line-height:1.55">${escapeHtml(excerpt)}</div>` : ''}
 ${metaLine(article)}
-<div style="margin-top:6px">${articleLinks(article)}</div>
+<div style="margin-top:9px">${articleLinks(article)}</div>
 </div>`;
 }
 
 function compactArticleHtml(article: ArticleMeta): string {
   const excerpt = truncateExcerpt(article.excerpt || '');
-  return `<div style="padding:10px 0;border-top:1px solid #f0ebe7">
-<a href="${escapeHtml(article.url)}" style="font-size:15px;color:#1a1a1a;text-decoration:none;font-weight:500;line-height:1.3">${escapeHtml(article.title)}</a>
-${excerpt ? `<div style="font-size:13px;color:#666;margin-top:3px;line-height:1.4">${escapeHtml(excerpt)}</div>` : ''}
+  const link = escapeHtml(pullReadLink(article));
+  return `<div style="padding:16px 0;border-top:1px solid #f0ebe6">
+<a href="${link}" style="font-size:15px;color:#1a1a1a;text-decoration:none;font-weight:600;line-height:1.4">${escapeHtml(article.title)}</a>
+${excerpt ? `<div style="font-size:13px;color:#6b6560;margin-top:5px;line-height:1.5">${escapeHtml(excerpt)}</div>` : ''}
 ${metaLine(article)}
-<div style="margin-top:4px">${articleLinks(article)}</div>
+<div style="margin-top:8px">${articleLinks(article)}</div>
 </div>`;
 }
 
 function categorySection(name: string, articles: ArticleMeta[]): string {
   const label = name.toUpperCase();
-  let html = `<div style="margin-top:28px;margin-bottom:12px">
-<div style="font-size:11px;font-weight:700;color:#b45535;letter-spacing:0.08em;text-transform:uppercase;padding-bottom:8px;border-bottom:2px solid #b45535">${escapeHtml(label)}</div>
+  let html = `<div style="margin:38px 0 20px">
+<div style="font-size:11px;font-weight:700;color:#b45535;letter-spacing:0.12em;text-transform:uppercase;padding-bottom:10px;border-bottom:1px solid #ece7e2">${escapeHtml(label)}</div>
 </div>`;
 
   // First article gets hero treatment
@@ -205,7 +216,31 @@ function categorySection(name: string, articles: ArticleMeta[]): string {
   return html;
 }
 
-export function buildRoundupHtml(articles: ArticleMeta[], lookbackDays: number, summary?: string | null): string {
+/**
+ * Split the AI editorial note into paragraphs so it reads like a reporter's
+ * briefing rather than one dense block. Honors blank-line paragraph breaks,
+ * falling back to single newlines, then to the whole note as one paragraph.
+ */
+function renderSummaryParagraphs(summary: string): string {
+  const byBlank = summary.split(/\n\s*\n/).map(s => s.trim()).filter(Boolean);
+  const paras = byBlank.length > 1
+    ? byBlank
+    : summary.split(/\n+/).map(s => s.trim()).filter(Boolean);
+  const finalParas = paras.length ? paras : [summary.trim()];
+  return finalParas
+    .map((p, i) => {
+      const mb = i === finalParas.length - 1 ? '0' : '15px';
+      return `<p style="margin:0 0 ${mb};font-size:16px;line-height:1.72;color:#33302d">${escapeHtml(p)}</p>`;
+    })
+    .join('\n');
+}
+
+export function buildRoundupHtml(
+  articles: ArticleMeta[],
+  lookbackDays: number,
+  summary?: string | null,
+  summaryModel?: string | null,
+): string {
   const today = new Date().toLocaleDateString('en-US', {
     weekday: 'long', month: 'long', day: 'numeric', year: 'numeric',
   });
@@ -220,29 +255,36 @@ export function buildRoundupHtml(articles: ArticleMeta[], lookbackDays: number, 
 <head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><meta name="color-scheme" content="light only"><meta name="supported-color-schemes" content="light only">
 <style>:root{color-scheme:light only}body,table,td,div,p,a,span{color-scheme:light only}</style>
 </head>
-<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background-color:#f7f5f3;color:#1a1a1a">
-<div style="max-width:600px;margin:0 auto;padding:20px;background-color:#f7f5f3">
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;background-color:#f7f5f3;color:#1a1a1a;-webkit-font-smoothing:antialiased">
+<div style="max-width:600px;margin:0 auto;padding:28px 20px 32px;background-color:#f7f5f3">
 
-<div style="text-align:center;padding:24px 0 16px">
+<div style="text-align:center;padding:8px 0 22px">
 <a href="https://pullread.com" style="text-decoration:none"><img src="cid:header" width="300" height="55" alt="Pull Read — The Rundown" style="display:inline-block" /></a>
 </div>
 
-<div style="background:#ffffff;padding:32px;border:1px solid #e8e3de">
+<div style="background:#ffffff;padding:40px;border:1px solid #ebe5df;border-radius:14px">
 
-<div style="text-align:center;margin-bottom:24px">
-<div style="font-size:20px;font-weight:600;color:#1a1a1a;font-family:Georgia,'Times New Roman',serif;margin-bottom:4px">The Rundown</div>
-<div style="font-size:13px;color:#999">${escapeHtml(today)} &middot; ${count} article${count === 1 ? '' : 's'} from ${period}</div>
+<div style="text-align:center;padding-bottom:24px;margin-bottom:30px;border-bottom:1px solid #ece7e2">
+<div style="font-size:27px;font-weight:600;color:#1a1a1a;font-family:Georgia,'Times New Roman',serif;letter-spacing:-0.01em;margin-bottom:6px">The Rundown</div>
+<div style="font-size:13px;color:#9a938c;letter-spacing:0.01em">${escapeHtml(today)} &middot; ${count} article${count === 1 ? '' : 's'} from ${period}</div>
 </div>
 `;
 
   if (summary) {
-    html += `<div style="font-size:15px;color:#444;line-height:1.6;padding:16px 20px;background:#faf8f6;border-left:3px solid #b45535;margin-bottom:24px;font-style:italic">${escapeHtml(summary)}</div>`;
+    const disclosure = summaryModel
+      ? `\n<div style="margin-top:20px;padding-top:15px;border-top:1px solid #efe4dc;font-size:12px;color:#a99f95;letter-spacing:0.01em">`
+        + `<span style="color:#b45535">&#10022;</span> This intro was written by `
+        + `<span style="color:#7d746b;font-weight:600">${escapeHtml(summaryModel)}</span></div>`
+      : '';
+    html += `<div style="background:#faf8f6;border:1px solid #efe7df;border-left:3px solid #b45535;border-radius:10px;padding:26px 28px;margin-bottom:34px">
+${renderSummaryParagraphs(summary)}${disclosure}
+</div>`;
   }
 
   if (articles.length === 0) {
-    html += `<div style="text-align:center;padding:32px 0">
-<div style="font-size:24px;margin-bottom:12px">&mdash;</div>
-<div style="font-size:15px;color:#666;line-height:1.5">Nothing new ${lookbackDays === 1 ? 'today' : 'recently'}. Enjoy the quiet.</div>
+    html += `<div style="text-align:center;padding:40px 0">
+<div style="font-size:26px;margin-bottom:14px;color:#c9c1b9">&mdash;</div>
+<div style="font-size:15px;color:#6b6560;line-height:1.5">Nothing new ${lookbackDays === 1 ? 'today' : 'recently'}. Enjoy the quiet.</div>
 </div>`;
   } else {
     const groups = groupByCategory(articles);
@@ -253,8 +295,8 @@ export function buildRoundupHtml(articles: ArticleMeta[], lookbackDays: number, 
 
   html += `</div>
 
-<div style="text-align:center;padding:20px 0 8px">
-<div style="font-size:11px;color:#b3a99e">Sent by <a href="https://pullread.com" style="color:#b3a99e;text-decoration:none">Pull Read</a></div>
+<div style="text-align:center;padding:24px 0 8px">
+<div style="font-size:11px;color:#b3a99e;letter-spacing:0.02em">Sent by <a href="https://pullread.com" style="color:#b45535;text-decoration:none;font-weight:500">Pull Read</a></div>
 </div>
 
 </div>
@@ -266,6 +308,75 @@ export function buildRoundupHtml(articles: ArticleMeta[], lookbackDays: number, 
 
 export function escapeHtml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+/**
+ * Turn a raw model id into a reader-friendly name for the AI-disclosure byline
+ * (e.g. `claude-haiku-4-5-20251001` → "Claude Haiku 4.5", `gpt-5-mini` → "GPT-5
+ * mini"). Falls back to a title-cased cleanup for models we don't special-case.
+ */
+function prettyModelName(model: string): string {
+  const raw = (model || '').trim();
+  if (!raw) return 'an AI model';
+  const lower = raw.toLowerCase();
+
+  // Claude: claude-haiku-4-5-20251001 / claude-opus-4.7 → Claude Haiku 4.5 / Claude Opus 4.7
+  let m = lower.match(/^claude-(haiku|sonnet|opus)-(\d+)[-.](\d+)/);
+  if (m) {
+    const tier = m[1].charAt(0).toUpperCase() + m[1].slice(1);
+    return `Claude ${tier} ${m[2]}.${m[3]}`;
+  }
+  if (lower.startsWith('claude')) return 'Claude';
+
+  // OpenAI GPT: gpt-5 / gpt-5-mini / gpt-4.1-nano → GPT-5 / GPT-5 mini / GPT-4.1 nano
+  m = lower.match(/^gpt-(\d+(?:\.\d+)?)(?:-(nano|mini|turbo))?/);
+  if (m) {
+    return `GPT-${m[1]}${m[2] ? ` ${m[2]}` : ''}`;
+  }
+  // OpenAI o-series: o3-mini → o3-mini
+  m = lower.match(/^o(\d+)(?:-(nano|mini))?/);
+  if (m) {
+    return `o${m[1]}${m[2] ? `-${m[2]}` : ''}`;
+  }
+
+  // Gemini: gemini-2.5-flash-lite → Gemini 2.5 Flash Lite
+  m = lower.match(/^gemini-(\d+(?:\.\d+)?)-(flash-lite|flash|pro)/);
+  if (m) {
+    const tierMap: Record<string, string> = { 'flash-lite': 'Flash Lite', 'flash': 'Flash', 'pro': 'Pro' };
+    return `Gemini ${m[1]} ${tierMap[m[2]]}`;
+  }
+  if (lower.startsWith('gemini')) return 'Gemini';
+
+  // Fallback: strip an OpenRouter ":free" tag, split on separators, title-case words.
+  return raw
+    .replace(/:free$/i, '')
+    .replace(/[-_/]+/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(w => (/^\d/.test(w) ? w : w.charAt(0).toUpperCase() + w.slice(1)))
+    .join(' ')
+    .trim() || 'an AI model';
+}
+
+/**
+ * Human-readable disclosure of which model wrote the editorial intro. Keeps the
+ * hosting provider visible when it isn't obvious from the model name (Apple's
+ * on-device model, OpenRouter-routed models).
+ */
+export function formatModelDisclosure(provider: string, model: string): string {
+  const raw = (model || '').trim();
+  const lower = raw.toLowerCase();
+
+  if (provider === 'apple' || lower === 'on-device' || lower.includes('apple')) {
+    return 'Apple Intelligence (on-device)';
+  }
+
+  if (provider === 'openrouter') {
+    const base = raw.includes('/') ? raw.split('/').pop() || raw : raw;
+    return `${prettyModelName(base)} (via OpenRouter)`;
+  }
+
+  return prettyModelName(raw);
 }
 
 async function validateArticleImages(articles: ArticleMeta[]): Promise<void> {
@@ -341,20 +452,32 @@ export function curateArticles(
   return picked;
 }
 
-const ROUNDUP_SUMMARY_PROMPT = `You're writing the opening note for a daily reading rundown. Think of yourself as the reader's sharpest, most well-read friend — someone who genuinely finds this stuff fascinating and wants to share why. Your voice is warm but not saccharine, opinionated but not preachy, witty but never try-hard.
+const ROUNDUP_SUMMARY_PROMPT = `You're writing the opening note for a daily reading rundown — the short briefing that sits at the very top of the newsletter. Write like a sharp, well-read reporter giving a curious friend the lay of the land: warm, direct, and genuinely interested, never breathless or salesy.
 
-Rules:
-- Write 2-3 sentences. No more.
-- Dive straight in. No "Welcome to" or "In today's rundown" throat-clearing.
-- Don't list articles or name-drop every piece. Synthesize the themes.
-- Be direct. "This matters because..." is better than "It's interesting to note that..."
-- A good line has texture. "The AI safety debate is heating up" is flat. Give it life.
-- Never use: "dive in", "buckle up", "without further ado", "let's get started", "here's what caught my eye".
+Structure:
+- Write 2 to 3 SHORT paragraphs. Separate every paragraph with a blank line.
+- Keep each paragraph to 1-2 sentences. Tight beats long.
+- Open with the day's throughline — the theme or tension tying the stories together — not a roll call.
 
-Articles:
+Voice:
+- Synthesize; don't enumerate. Never march down the list tacking "and it's a reminder that…" onto each item. That pattern is the single worst thing you can do here.
+- Be specific. Name the real stakes. "The AI debate is heating up" is flat — say what actually shifted and why it lands.
+- Opinions welcome, clichés not.
+- Don't name every article or count how many there are.
+
+Never use: "dive in", "buckle up", "without further ado", "let's get started", "here's what caught my eye", "in today's rundown", "welcome to".
+
+Today's articles:
 `;
 
-export async function generateRoundupSummary(articles: ArticleMeta[]): Promise<string | null> {
+/** The editorial intro plus the model that wrote it, for AI disclosure. */
+export interface RoundupSummary {
+  text: string;
+  model: string;
+  provider: string;
+}
+
+export async function generateRoundupSummary(articles: ArticleMeta[]): Promise<RoundupSummary | null> {
   const { promptLLM, loadLLMConfig } = await import('./summarizer');
   const config = loadLLMConfig();
   if (!config) return null;
@@ -371,10 +494,13 @@ export async function generateRoundupSummary(articles: ArticleMeta[]): Promise<s
   // summarizeText would prepend its own "Summarize this article…" wrapper, so the
   // model would summarize our instructions instead of following them — producing a
   // near-static blurb anchored on the example lines in ROUNDUP_SUMMARY_PROMPT.
+  // A slightly higher token budget lets the model write 2-3 short paragraphs.
   const prompt = ROUNDUP_SUMMARY_PROMPT + articleList;
   try {
-    const result = await promptLLM(prompt, config, 300);
-    return result.text.trim() || null;
+    const result = await promptLLM(prompt, config, 400);
+    const text = result.text.trim();
+    if (!text) return null;
+    return { text, model: result.model, provider: config.provider };
   } catch (err) {
     console.warn('[email] Failed to generate roundup summary:', err instanceof Error ? err.message : err);
     return null;
@@ -385,6 +511,8 @@ export interface RoundupResult {
   html: string;
   subject: string;
   summary: string | null;
+  /** Reader-friendly name of the model that wrote the intro, if any. */
+  summaryModel: string | null;
   articles: ArticleMeta[];
 }
 
@@ -445,13 +573,17 @@ export async function buildRoundup(
   await validateArticleImages(curated);
 
   // Generate AI editorial summary (non-blocking — roundup renders even if this fails)
-  const summary = await generateRoundupSummary(curated);
+  const summaryResult = await generateRoundupSummary(curated);
+  const summary = summaryResult?.text ?? null;
+  const summaryModel = summaryResult
+    ? formatModelDisclosure(summaryResult.provider, summaryResult.model)
+    : null;
 
-  const html = buildRoundupHtml(curated, cfg.lookbackDays, summary);
+  const html = buildRoundupHtml(curated, cfg.lookbackDays, summary, summaryModel);
   const today = new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric' });
   const subject = `The Pull Read Rundown — ${today}`;
 
-  return { html, subject, summary, articles: curated };
+  return { html, subject, summary, summaryModel, articles: curated };
 }
 
 export async function sendRoundup(

--- a/src/email.ts
+++ b/src/email.ts
@@ -120,18 +120,65 @@ function truncateExcerpt(text: string, max = 120): string {
   return text.slice(0, max).replace(/\s+\S*$/, '') + '\u2026';
 }
 
-function groupByCategory(articles: ArticleMeta[]): Map<string, ArticleMeta[]> {
+// Deterministic per-key rotation derived from a daily seed, so sections that
+// tie on strength (e.g. a quiet day where nothing scores) still reshuffle from
+// one issue to the next instead of freezing into a fixed order.
+function rotationKey(key: string, seed: string): number {
+  let h = 2166136261;
+  const s = `${seed}|${key}`;
+  for (let i = 0; i < s.length; i++) {
+    h = Math.imul(h ^ s.charCodeAt(i), 16777619) >>> 0;
+  }
+  return h;
+}
+
+export interface GroupOptions {
+  /** Per-article relevance score; when given, sections and stories are ranked by it. */
+  score?: (a: ArticleMeta) => number;
+  /** Daily seed for the tie-break rotation (keeps quiet days varying). */
+  seed?: string;
+}
+
+/**
+ * Group articles by their primary category. With a `score` function, sections
+ * are ordered by their combined strength (strongest section leads, so the lead
+ * changes with the news) and each section's strongest story sorts first (it
+ * becomes the hero); "More" stays last and ties break on a daily rotation.
+ * Without a score, falls back to the legacy alphabetical order.
+ */
+export function groupByCategory(articles: ArticleMeta[], opts: GroupOptions = {}): Map<string, ArticleMeta[]> {
   const groups = new Map<string, ArticleMeta[]>();
   for (const a of articles) {
     const cat = a.categories?.[0] || 'More';
     if (!groups.has(cat)) groups.set(cat, []);
     groups.get(cat)!.push(a);
   }
-  // Sort: named categories alphabetically, "More" last
+
+  const { score, seed = '' } = opts;
+
+  if (score) {
+    // Strongest story first within each section — it becomes the hero.
+    for (const list of groups.values()) {
+      list.sort((a, b) => score(b) - score(a));
+    }
+  }
+
+  const strength = new Map<string, number>();
+  if (score) {
+    for (const [cat, list] of groups) {
+      strength.set(cat, list.reduce((sum, a) => sum + score(a), 0));
+    }
+  }
+
   const sorted = new Map<string, ArticleMeta[]>();
   const keys = [...groups.keys()].sort((a, b) => {
     if (a === 'More') return 1;
     if (b === 'More') return -1;
+    if (score) {
+      const diff = (strength.get(b) || 0) - (strength.get(a) || 0);
+      if (Math.abs(diff) > 1e-9) return diff;
+      return rotationKey(a, seed) - rotationKey(b, seed);
+    }
     return a.localeCompare(b);
   });
   for (const k of keys) sorted.set(k, groups.get(k)!);
@@ -234,6 +281,7 @@ export function buildRoundupHtml(
   lookbackDays: number,
   summary?: string | null,
   summaryCredit?: string | null,
+  scoreFn?: ((a: ArticleMeta) => number) | null,
 ): string {
   const today = new Date().toLocaleDateString('en-US', {
     weekday: 'long', month: 'long', day: 'numeric', year: 'numeric',
@@ -285,7 +333,9 @@ ${renderSummaryParagraphs(summary, citationUrls)}${credit}
 <div style="font-size:15px;color:#6b6560;line-height:1.5">Nothing new ${lookbackDays === 1 ? 'today' : 'recently'}. Enjoy the quiet.</div>
 </div>`;
   } else {
-    const groups = groupByCategory(articles);
+    // Rank sections by the day's signal (seed = today's date) so the lead
+    // section changes with the news instead of freezing alphabetically.
+    const groups = groupByCategory(articles, scoreFn ? { score: scoreFn, seed: today } : {});
     for (const [cat, catArticles] of groups) {
       html += categorySection(cat, catArticles);
     }
@@ -359,6 +409,58 @@ async function validateArticleImages(articles: ArticleMeta[]): Promise<void> {
 
 const MAX_ROUNDUP_ARTICLES = 12;
 
+export interface ScoreContext {
+  /** Current time in ms, for recency scoring. */
+  now: number;
+  mentionCounts?: Map<string, number>;
+  watchedEntities?: Set<string>;
+}
+
+/**
+ * Freshness boost: a story bookmarked minutes ago outweighs one from yesterday.
+ * Bounded to [0, 3] and decays to zero over ~24h so it nudges ordering without
+ * swamping the relevance signals.
+ */
+function recencyBoost(bookmarked: string | undefined, now: number): number {
+  if (!bookmarked) return 0;
+  const t = Date.parse(bookmarked);
+  if (Number.isNaN(t)) return 0;
+  const hoursAgo = (now - t) / 3_600_000;
+  if (hoursAgo <= 0) return 3;
+  return Math.max(0, 3 - hoursAgo / 8);
+}
+
+/**
+ * Relevance score for one article, combining freshness, content richness, and
+ * research-graph / watched-entity signals. Used both to curate (which stories
+ * make the cut) and to rank sections (which section leads the issue).
+ */
+export function scoreArticle(a: ArticleMeta, ctx: ScoreContext): number {
+  let score = 0;
+  // Freshness — the strongest lever for making each day's ordering feel different.
+  score += recencyBoost(a.bookmarked, ctx.now);
+  // Richer content (excerpt, image) reads better as a lead.
+  if (a.excerpt) score += 1;
+  if (a.image?.startsWith('http')) score += 1;
+  // Watched/trending entities in the title.
+  if (ctx.mentionCounts && ctx.watchedEntities) {
+    const titleLower = a.title.toLowerCase();
+    for (const entity of ctx.watchedEntities) {
+      if (titleLower.includes(entity.toLowerCase())) score += 3;
+    }
+  }
+  // Research-graph mentions.
+  if (ctx.mentionCounts) {
+    const titleWords = a.title.toLowerCase().split(/\s+/);
+    for (const [entity, count] of ctx.mentionCounts) {
+      if (titleWords.some(w => entity.toLowerCase().includes(w) && w.length > 3)) {
+        score += Math.min(count, 5);
+      }
+    }
+  }
+  return score;
+}
+
 export function curateArticles(
   articles: ArticleMeta[],
   mentionCounts?: Map<string, number>,
@@ -367,31 +469,8 @@ export function curateArticles(
 ): ArticleMeta[] {
   if (articles.length <= limit) return articles;
 
-  // Score each article based on signals
-  const scored = articles.map(a => {
-    let score = 0;
-    // Boost articles with excerpts (richer content)
-    if (a.excerpt) score += 1;
-    // Boost articles with images (visual interest)
-    if (a.image?.startsWith('http')) score += 1;
-    // Boost articles that mention watched/trending entities
-    if (mentionCounts && watchedEntities) {
-      const titleLower = a.title.toLowerCase();
-      for (const entity of watchedEntities) {
-        if (titleLower.includes(entity.toLowerCase())) score += 3;
-      }
-    }
-    // Boost articles with research graph mentions
-    if (mentionCounts) {
-      const titleWords = a.title.toLowerCase().split(/\s+/);
-      for (const [entity, count] of mentionCounts) {
-        if (titleWords.some(w => entity.toLowerCase().includes(w) && w.length > 3)) {
-          score += Math.min(count, 5);
-        }
-      }
-    }
-    return { article: a, score };
-  });
+  const ctx: ScoreContext = { now: Date.now(), mentionCounts, watchedEntities };
+  const scored = articles.map(a => ({ article: a, score: scoreArticle(a, ctx) }));
 
   // Sort by score descending, then ensure category diversity
   scored.sort((a, b) => b.score - a.score);
@@ -547,7 +626,10 @@ export async function buildRoundup(
     ? formatSummaryCredit(summaryResult.provider, summaryResult.model)
     : null;
 
-  const html = buildRoundupHtml(curated, cfg.lookbackDays, summary, summaryCredit);
+  // Rank sections by the day's relevance/freshness so the lead changes daily.
+  const scoreCtx: ScoreContext = { now: Date.now(), mentionCounts, watchedEntities };
+  const scoreFn = (a: ArticleMeta) => scoreArticle(a, scoreCtx);
+  const html = buildRoundupHtml(curated, cfg.lookbackDays, summary, summaryCredit, scoreFn);
   const today = new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric' });
   const subject = `The Pull Read Rundown — ${today}`;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -590,7 +590,7 @@ if (command === 'sync') {
     writeFileSync(outPath, result.html);
     console.log(`Articles in last ${cfg.lookbackDays} day${cfg.lookbackDays === 1 ? '' : 's'}: ${result.articles.length}`);
     console.log(`Editorial note: ${result.summary ?? '(none — no LLM configured, or generation failed)'}`);
-    if (result.summaryModel) console.log(`Intro written by: ${result.summaryModel}`);
+    if (result.summaryCredit) console.log(`Summary by: ${result.summaryCredit}`);
     console.log(`Wrote preview to ${outPath}`);
     if (result.articles.length === 0) {
       console.log('Note: no bookmarked articles in the window, so the summary will be empty. Bookmark a few recent articles and re-run.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -590,6 +590,7 @@ if (command === 'sync') {
     writeFileSync(outPath, result.html);
     console.log(`Articles in last ${cfg.lookbackDays} day${cfg.lookbackDays === 1 ? '' : 's'}: ${result.articles.length}`);
     console.log(`Editorial note: ${result.summary ?? '(none — no LLM configured, or generation failed)'}`);
+    if (result.summaryModel) console.log(`Intro written by: ${result.summaryModel}`);
     console.log(`Wrote preview to ${outPath}`);
     if (result.articles.length === 0) {
       console.log('Note: no bookmarked articles in the window, so the summary will be empty. Bookmark a few recent articles and re-run.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -584,7 +584,7 @@ if (command === 'sync') {
   (async () => {
     const { buildRoundup, filterByLookback, loadEmailConfig } = await import('./email');
     const cfg = loadEmailConfig();
-    const fetchArticles = async () => filterByLookback(listFiles(config.outputPath), cfg.lookbackDays);
+    const fetchArticles = async () => filterByLookback(listFiles(config.outputPath, true), cfg.lookbackDays);
     const result = await buildRoundup(cfg, fetchArticles);
 
     writeFileSync(outPath, result.html);

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -29,6 +29,8 @@ interface FileMeta {
   hasSummary: boolean;
   summaryProvider: string;
   summaryModel: string;
+  /** Stored AI summary text — only populated when listFiles is asked for it. */
+  summary?: string;
   excerpt: string;
   image: string;
   favicon: string;
@@ -444,7 +446,7 @@ function resolveRelPath(base: string, rel: string): string {
   return resolved.join('/');
 }
 
-export function listFiles(outputPath: string): FileMeta[] {
+export function listFiles(outputPath: string, includeSummaries = false): FileMeta[] {
   if (!existsSync(outputPath)) return [];
 
   const files: FileMeta[] = [];
@@ -507,6 +509,7 @@ export function listFiles(outputPath: string): FileMeta[] {
         hasSummary: !!meta.summary,
         summaryProvider: meta.summaryProvider || '',
         summaryModel: meta.summaryModel || '',
+        ...(includeSummaries && meta.summary ? { summary: meta.summary.slice(0, 500) } : {}),
         excerpt: meta.excerpt || '',
         image,
         favicon: meta.favicon || '',
@@ -951,7 +954,7 @@ iframe{width:100%;height:100%;border:none;position:absolute;top:0;left:0}
     }
 
     if (url.pathname === '/api/files') {
-      sendJson(res, listFiles(outputPath));
+      sendJson(res, listFiles(outputPath, url.searchParams.get('summaries') === '1'));
       return;
     }
 


### PR DESCRIPTION
## Summary

Redesigned the email roundup to rank sections by relevance/freshness instead of alphabetically, integrate AI model disclosure, and simplify the article link strategy. The changes make each day's newsletter feel dynamically curated while being transparent about AI-generated content.

## Key Changes

- **Section ranking by relevance**: Added `scoreArticle()` and `ScoreContext` to score articles by freshness (recency boost), content richness (excerpt/image), and watched entities. Sections now rank by combined strength, so the lead changes with the news instead of freezing alphabetically. Ties break on a daily rotation (deterministic per-seed) to keep quiet days varying.

- **Deterministic tie-breaking**: Introduced `rotationKey()` hash function that uses a daily seed (today's date) to reshuffle tied sections across days without freezing into a fixed order.

- **Simplified article links**: Removed per-item "Open in Pull Read" and "Read →" CTAs. Headlines now link directly to the source, making the design cleaner and mobile-friendly. The whole hero article is the link.

- **AI model disclosure**: 
  - `generateRoundupSummary()` now returns a `RoundupSummary` object with `text`, `model`, and `provider` fields
  - Added `formatSummaryCredit()` to derive brand-level credit (e.g., "Claude", "GPT", "Gemini") from provider and model, without exposing version details
  - Editorial intro now displays "Summary by [Brand]" when AI-generated

- **Enhanced summary rendering**:
  - `renderSummaryParagraphs()` splits the intro into paragraphs (blank-line breaks, then single newlines) for a briefing-like structure
  - Supports inline story citations: `{{linked words|N}}` syntax links to the Nth article in the curated list
  - Strips unmatched or out-of-range citation markers while preserving the text

- **Responsive hero layout**: Added `.hero-cell` and `.hero-img` classes with a media query to stack image above text on mobile (≤600px), replacing fixed side-by-side layout.

- **Updated styling**: Refined colors, spacing, typography, and borders throughout for a cleaner, more refined appearance. Removed boxed callout styling from the editorial note (now a plain lede).

- **Export new utilities**: `groupByCategory()`, `scoreArticle()`, and `formatSummaryCredit()` are now exported for testing and reuse.

## Implementation Details

- `groupByCategory()` now accepts a `GroupOptions` object with optional `score` and `seed` functions. When a score is provided, it sorts articles within sections by score (strongest first, becoming the hero) and sections by combined strength, with "More" always last.
- Recency boost decays over ~24 hours (bounded to [0, 3]) so freshness nudges ordering without overwhelming other signals.
- The roundup prompt was refined to encourage 2–3 short paragraphs with a clear throughline, and to use the numbered-story citation syntax for inline linking.
- `buildRoundupHtml()` signature expanded to accept `summaryCredit` and `scoreFn` parameters, enabling dynamic section ranking and AI disclosure in the rendered HTML.
- Tests updated to verify section ranking, tie-breaking, citation linking, paragraph splitting, and AI credit display.

https://claude.ai/code/session_01Jm1FbVpDJFTGMkC9DUxfwF