### PR TITLE
Release 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pullread",
-  "version": "0.4.10",
+  "version": "0.5.0",
   "description": "Sync Drafty bookmarks to markdown files",
   "main": "src/index.ts",
   "scripts": {

--- a/site/releases.html
+++ b/site/releases.html
@@ -133,6 +133,22 @@
 <!-- Releases -->
 <div class="releases">
 
+  <div class="release-card reveal" id="v0.5.0">
+    <div class="release-header">
+      <span class="release-version">0.5.0</span>
+      <span class="release-subtitle">"Above the Fold"</span>
+    </div>
+    <div class="release-date">July 2026</div>
+    <ul>
+      <li>The Rundown email got a redesign &mdash; cleaner article cards, hero images for lead stories, and sections ranked by the day&rsquo;s signal so the biggest news leads instead of whatever comes first alphabetically.</li>
+      <li>The opening note now reads like a real briefing &mdash; it draws on your articles&rsquo; actual summaries and links the stories it mentions inline, just like the in-app Rundown.</li>
+      <li>AI disclosure &mdash; the email credits which AI wrote the intro, right under the note.</li>
+      <li>No more filler &mdash; &ldquo;let&rsquo;s get started&rdquo; openers, &ldquo;that&rsquo;s all for today&rdquo; sign-offs, and off-topic ramble are stripped before the email goes out.</li>
+      <li>Apple Intelligence fix &mdash; on busy days the intro could silently vanish (the on-device model ran out of context); the prompt now sizes itself to fit, so the note always arrives.</li>
+      <li>Mobile email layout &mdash; hero images stack above their headlines on small screens instead of squeezing beside them.</li>
+    </ul>
+  </div>
+
   <div class="release-card reveal" id="v0.4.10">
     <div class="release-header">
       <span class="release-version">0.4.10</span>

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pullread"
-version = "0.4.10"
+version = "0.5.0"
 description = "Sync articles from RSS feeds, bookmarks, and newsletters to searchable markdown files"
 authors = ["PullRead"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pull Read",
-  "version": "0.4.10",
+  "version": "0.5.0",
   "identifier": "com.pullread.desktop",
   "build": {
     "beforeBuildCommand": "bun run scripts/embed-viewer.ts",

--- a/viewer/03-settings.js
+++ b/viewer/03-settings.js
@@ -957,7 +957,7 @@ function showSettingsPage(scrollToSection) {
   html += '</div>';
   html += '<div style="display:flex;gap:12px;flex-wrap:wrap;padding:8px 0">';
   html += '<a href="https://pullread.com" target="_blank" rel="noopener" style="font-size:13px;color:var(--link)">pullread.com</a>';
-  html += '<a href="#" onclick="prOpenExternal(\'https://pullread.com/releases#v\' + (window._prCurrentVersion || \'0.4.10\'));return false" style="font-size:13px;color:var(--link)">What\'s New</a>';
+  html += '<a href="#" onclick="prOpenExternal(\'https://pullread.com/releases#v\' + (window._prCurrentVersion || \'0.5.0\'));return false" style="font-size:13px;color:var(--link)">What\'s New</a>';
   html += '<a href="/api/log" target="_blank" style="font-size:13px;color:var(--link)">View Logs</a>';
   html += '<button style="font-size:13px;padding:6px 16px;background:var(--bg);color:var(--fg);border:1px solid var(--border);border-radius:6px;cursor:pointer;font-family:inherit" onclick="showTour()">Show Tour</button>';
   html += '</div>';


### PR DESCRIPTION
Version bump and release notes for 0.5.0 "Above the Fold" — the Rundown email redesign (scoring, ranking, AI disclosure) plus the summary-grounded, linked editorial intro and Apple Intelligence context fix from #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdXEsWQTadb9qbTQjLkMqn