### PR TITLE
Usage metrics phase 1: stats endpoint, weekly snapshots, gated README links

### DIFF
--- a/.github/workflows/metrics-snapshot.yml
+++ b/.github/workflows/metrics-snapshot.yml
@@ -1,0 +1,42 @@
+# ABOUTME: Weekly snapshot of download/usage metrics into data/metrics.csv.
+# ABOUTME: Rescues ephemeral GitHub counters (14-day traffic, resetting rolling-DMG counts). See #111.
+
+name: Metrics Snapshot
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'  # Every Monday at 8am UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Collect metrics
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Optional: set PULLREAD_STATS_KEY (the worker ADMIN_KEY) in repo secrets
+          # to include download-gate subscriber counts in the snapshot.
+          STATS_KEY: ${{ secrets.PULLREAD_STATS_KEY }}
+        run: bun scripts/metrics-snapshot.ts
+
+      - name: Commit snapshot
+        run: |
+          if [ -z "$(git status --porcelain data/metrics.csv)" ]; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/metrics.csv
+          git commit -m "chore: metrics snapshot $(date -u +%Y-%m-%d) [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ PullRead connects to bookmark services like Instapaper, Pinboard, Raindrop, and 
 
 ## Download
 
-**[Download the latest release](https://github.com/shellen/pullread/releases/latest)**
+**[Download Pull Read from pullread.com](https://pullread.com/#download)**
 
 | Platform | Download | Architecture |
 |----------|----------|-------------|
-| **macOS (Apple Silicon)** | [PullRead_aarch64.dmg](https://github.com/shellen/pullread/releases/latest) | ARM64 (M1/M2/M3/M4) |
-| **macOS (Intel)** | [PullRead_x64.dmg](https://github.com/shellen/pullread/releases/latest) | x86_64 |
+| **macOS (Apple Silicon)** | [pullread.com/#download](https://pullread.com/#download) | ARM64 (M1/M2/M3/M4) |
+| **macOS (Intel)** | [pullread.com/#download](https://pullread.com/#download) | x86_64 |
 | **CLI** | Clone this repo | For development, Linux, or Windows |
 
 > **Quick install:** Download the DMG, open it, drag PullRead to your Applications folder, and launch it. The app is fully self-contained — no Node.js or other dependencies required. Configure your feeds in Settings and start syncing.
@@ -131,7 +131,7 @@ npm run sync -- --help
 
 **Option A: Download Release (Recommended)**
 
-1. Download `PullRead.dmg` from [GitHub Releases](https://github.com/shellen/pullread/releases)
+1. Download `PullRead.dmg` from [pullread.com](https://pullread.com/#download)
 2. Open the DMG and drag PullRead to Applications
 3. Launch PullRead from Applications
 4. The onboarding wizard walks you through setting up feeds and output path

--- a/scripts/metrics-snapshot.ts
+++ b/scripts/metrics-snapshot.ts
@@ -1,0 +1,105 @@
+// ABOUTME: Appends a dated snapshot of download/usage metrics to data/metrics.csv.
+// ABOUTME: Run weekly by .github/workflows/metrics-snapshot.yml; see issue #111.
+//
+// GitHub's counters are ephemeral (traffic stats cover a rolling 14 days; the
+// rolling `latest` prerelease DMG counter resets every time CI clobbers the
+// asset), so this snapshot is what turns them into trend lines.
+//
+// Env:
+//   GITHUB_TOKEN  - token with repo read (traffic API needs push access)
+//   REPO          - owner/name, default shellen/pullread
+//   STATS_URL     - optional, worker stats endpoint (e.g. https://pullread.com/api/stats)
+//   STATS_KEY     - optional, ADMIN_KEY for the stats endpoint
+
+import { existsSync, mkdirSync, appendFileSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+
+const REPO = process.env.REPO || 'shellen/pullread';
+const TOKEN = process.env.GITHUB_TOKEN || '';
+const CSV_PATH = join(import.meta.dir, '..', 'data', 'metrics.csv');
+const HEADER = 'date,metric,label,value\n';
+
+const today = new Date().toISOString().slice(0, 10);
+const rows: string[] = [];
+
+function addRow(metric: string, label: string, value: number | null | undefined) {
+  if (value === null || value === undefined) return;
+  // Labels are constrained (tags, asset names, source/platform enums) but
+  // quote anything with a comma just in case.
+  const safeLabel = label.includes(',') ? `"${label.replace(/"/g, '""')}"` : label;
+  rows.push(`${today},${metric},${safeLabel},${value}`);
+}
+
+async function gh(path: string): Promise<any | null> {
+  try {
+    const res = await fetch(`https://api.github.com${path}`, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        ...(TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {}),
+      },
+    });
+    if (!res.ok) {
+      console.warn(`[metrics] GET ${path} -> ${res.status} (skipping)`);
+      return null;
+    }
+    return await res.json();
+  } catch (err) {
+    console.warn(`[metrics] GET ${path} failed:`, err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
+// 1. Release asset download counts (tagged releases + the rolling `latest`)
+const releases = await gh(`/repos/${REPO}/releases?per_page=100`);
+if (Array.isArray(releases)) {
+  for (const rel of releases) {
+    for (const asset of rel.assets || []) {
+      if (!/\.dmg$|\.tar\.gz$|^latest\.json$/.test(asset.name)) continue;
+      if (rel.tag_name === 'latest') {
+        addRow('rolling_asset_downloads', asset.name, asset.download_count);
+      } else {
+        addRow('release_asset_downloads', `${rel.tag_name}/${asset.name}`, asset.download_count);
+      }
+    }
+  }
+}
+
+// 2. Repo traffic (rolling 14-day window — snapshotting is the only way to keep it)
+const views = await gh(`/repos/${REPO}/traffic/views`);
+addRow('traffic_views_14d', 'total', views?.count);
+addRow('traffic_views_14d', 'unique', views?.uniques);
+const clones = await gh(`/repos/${REPO}/traffic/clones`);
+addRow('traffic_clones_14d', 'total', clones?.count);
+addRow('traffic_clones_14d', 'unique', clones?.uniques);
+
+// 3. Download-gate subscriber counts from the worker (optional — needs STATS_KEY)
+if (process.env.STATS_KEY) {
+  const statsUrl = process.env.STATS_URL || 'https://pullread.com/api/stats';
+  try {
+    const res = await fetch(`${statsUrl}?key=${encodeURIComponent(process.env.STATS_KEY)}`);
+    if (res.ok) {
+      const stats: any = await res.json();
+      addRow('subscribers', 'total', stats.totals?.total);
+      addRow('subscribers', 'active', stats.totals?.active);
+      for (const g of stats.active_by_source_platform || []) {
+        addRow('subscribers_active', `${g.source}/${g.platform || 'none'}`, g.count);
+      }
+    } else {
+      console.warn(`[metrics] stats endpoint -> ${res.status} (skipping subscriber counts)`);
+    }
+  } catch (err) {
+    console.warn('[metrics] stats endpoint failed:', err instanceof Error ? err.message : err);
+  }
+} else {
+  console.warn('[metrics] STATS_KEY not set — skipping subscriber counts');
+}
+
+if (rows.length === 0) {
+  console.error('[metrics] No metrics collected — refusing to write an empty snapshot');
+  process.exit(1);
+}
+
+mkdirSync(dirname(CSV_PATH), { recursive: true });
+if (!existsSync(CSV_PATH)) writeFileSync(CSV_PATH, HEADER);
+appendFileSync(CSV_PATH, rows.join('\n') + '\n');
+console.log(`[metrics] Appended ${rows.length} rows to data/metrics.csv for ${today}`);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -147,6 +147,34 @@ async function handleExport(request: Request, env: Env): Promise<Response> {
   });
 }
 
+async function handleStats(request: Request, env: Env): Promise<Response> {
+  const url = new URL(request.url);
+  if (url.searchParams.get('key') !== env.ADMIN_KEY) {
+    return new Response('Forbidden', { status: 403 });
+  }
+
+  const totals = await env.DB.prepare(
+    'SELECT COUNT(*) AS total, SUM(unsubscribed_at IS NULL) AS active FROM subscribers',
+  ).first<{ total: number; active: number | null }>();
+
+  const bySourcePlatform = await env.DB.prepare(
+    "SELECT source, COALESCE(platform, '') AS platform, COUNT(*) AS count FROM subscribers WHERE unsubscribed_at IS NULL GROUP BY source, platform ORDER BY source, platform",
+  ).all();
+
+  const byWeek = await env.DB.prepare(
+    "SELECT strftime('%Y-%W', created_at) AS week, source, COUNT(*) AS count FROM subscribers GROUP BY week, source ORDER BY week",
+  ).all();
+
+  return new Response(
+    JSON.stringify({
+      totals: { total: totals?.total ?? 0, active: totals?.active ?? 0 },
+      active_by_source_platform: bySourcePlatform.results,
+      signups_by_week: byWeek.results,
+    }),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
@@ -165,6 +193,10 @@ export default {
 
     if (url.pathname === '/api/export') {
       return handleExport(request, env);
+    }
+
+    if (url.pathname === '/api/stats') {
+      return handleStats(request, env);
     }
 
     return new Response('Not found', { status: 404 });

--- a/worker/test/index.test.ts
+++ b/worker/test/index.test.ts
@@ -247,3 +247,36 @@ describe('GET /api/export', () => {
     expect(csv).toContain('active@example.com');
   });
 });
+
+// ── GET /api/stats ───────────────────────────────────────
+
+describe('GET /api/stats', () => {
+  test('valid key returns aggregate counts without emails', async () => {
+    await env.DB.prepare(
+      "INSERT INTO subscribers (email, source, platform) VALUES ('a@x.com', 'download', 'apple_silicon'), ('b@x.com', 'download', 'intel'), ('c@x.com', 'newsletter', NULL)",
+    ).run();
+    await env.DB.prepare(
+      "INSERT INTO subscribers (email, source, unsubscribed_at) VALUES ('gone@x.com', 'newsletter', datetime('now'))",
+    ).run();
+
+    const res = await SELF.fetch('https://fake.host/api/stats?key=test-admin-key');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.totals).toEqual({ total: 4, active: 3 });
+    expect(body.active_by_source_platform).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: 'download', platform: 'apple_silicon', count: 1 }),
+        expect.objectContaining({ source: 'download', platform: 'intel', count: 1 }),
+        expect.objectContaining({ source: 'newsletter', platform: '', count: 1 }),
+      ]),
+    );
+    expect(body.signups_by_week.length).toBeGreaterThan(0);
+    // Aggregates only — no addresses leave the worker via this route.
+    expect(JSON.stringify(body)).not.toContain('@x.com');
+  });
+
+  test('bad key returns 403', async () => {
+    const res = await SELF.fetch('https://fake.host/api/stats?key=nope');
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
Implements Phase 1 of #111.

- **Worker `/api/stats`** — `ADMIN_KEY`-protected JSON aggregates (totals, active by source/platform, signups by week). Never returns email addresses; covered by new vitest cases (17/17 pass).
- **`metrics-snapshot.yml`** — Mondays 08:00 UTC (+ manual dispatch), appends long-format rows to `data/metrics.csv`: per-release asset downloads, rolling `latest` counts before CI resets them, 14-day traffic, and (when `PULLREAD_STATS_KEY` is set in repo secrets) subscriber counts. Verified against the live GitHub API — 86 rows collected. Commits with `[skip ci]`.
- **README** — download links route through pullread.com's email-gated flow instead of raw GitHub asset URLs.

After merge:
1. Add `PULLREAD_STATS_KEY` (the worker's `ADMIN_KEY`) to repo Actions secrets.
2. Deploy the worker: `cd worker && npx wrangler deploy`.
3. Optionally trigger the first snapshot: Actions → Metrics Snapshot → Run workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdXEsWQTadb9qbTQjLkMqn